### PR TITLE
Redirect customers back to the payment task after enabling an offline gateway

### DIFF
--- a/changelogs/update-8242-tweak-flow-after-setting-up-offline-payments
+++ b/changelogs/update-8242-tweak-flow-after-setting-up-offline-payments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Tweak
+
+Redirect customers back to the payment task after enabling an offline payment gateway #8389

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -70,7 +70,9 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			const enrichedSuggestion = {
 				installed: !! mappedPaymentGateways[ id ],
 				postInstallScripts: installedGateway.post_install_scripts,
-				hasPlugins: suggestion.plugins && suggestion.plugins.length,
+				hasPlugins: !! (
+					suggestion.plugins && suggestion.plugins.length
+				),
 				enabled: installedGateway.enabled || false,
 				needsSetup: installedGateway.needs_setup,
 				settingsUrl: installedGateway.settings_url,

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -12,6 +12,7 @@ import { recordEvent } from '@woocommerce/tracks';
 import { useMemo, useCallback, useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
 import { WooOnboardingTask } from '@woocommerce/onboarding';
+import { getNewPath } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -121,7 +122,19 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 		updatePaymentGateway( id, {
 			enabled: true,
 		} ).then( () => {
-			onComplete();
+			onComplete(
+				// use the paymentGateways variable.
+				// gateway variable doesn't have hasPlugins property.
+				paymentGateways.get( id )?.hasPlugins === undefined
+					? {
+							redirectPath: getNewPath(
+								{ task: 'payments' },
+								{},
+								'/'
+							),
+					  }
+					: {}
+			);
 		} );
 	};
 

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -127,7 +127,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			onComplete(
 				// use the paymentGateways variable.
 				// gateway variable doesn't have hasPlugins property.
-				paymentGateways.get( id )?.hasPlugins
+				! paymentGateways.get( id )?.hasPlugins
 					? {
 							redirectPath: getNewPath(
 								{ task: 'payments' },

--- a/client/tasks/fills/PaymentGatewaySuggestions/index.js
+++ b/client/tasks/fills/PaymentGatewaySuggestions/index.js
@@ -127,7 +127,7 @@ export const PaymentGatewaySuggestions = ( { onComplete, query } ) => {
 			onComplete(
 				// use the paymentGateways variable.
 				// gateway variable doesn't have hasPlugins property.
-				paymentGateways.get( id )?.hasPlugins === undefined
+				paymentGateways.get( id )?.hasPlugins
 					? {
 							redirectPath: getNewPath(
 								{ task: 'payments' },

--- a/client/tasks/task.tsx
+++ b/client/tasks/task.tsx
@@ -26,11 +26,18 @@ export const Task: React.FC< TaskProps > = ( { query, task } ) => {
 		optimisticallyCompleteTask,
 	} = useDispatch( ONBOARDING_STORE_NAME );
 
-	const onComplete = useCallback( () => {
-		optimisticallyCompleteTask( id );
-		getHistory().push( getNewPath( {}, '/', {} ) );
-		invalidateResolutionForStoreSelector( 'getTaskLists' );
-	}, [ id ] );
+	const onComplete = useCallback(
+		( options ) => {
+			optimisticallyCompleteTask( id );
+			getHistory().push(
+				options && options.redirectPath
+					? options.redirectPath
+					: getNewPath( {}, '/', {} )
+			);
+			invalidateResolutionForStoreSelector( 'getTaskLists' );
+		},
+		[ id ]
+	);
 
 	return (
 		<>


### PR DESCRIPTION
Fixes #8242 

This PR redirects customers back to the payment task after enabling an offline payment gateway. This PR checks `hasPlugins` and assumes a gateway is offline if the value is `undefined`


### Detailed test instructions:

1. Make sure offline payment gateways are not enabled. If they're, disable them from `WooCommerce -> Settings -> Payments`
2. Navigate to `WooCommerce -> Home` and click `Setup payments` task.
3. Enable COD or Direct bank transfer.
4. You should be redirected back to the payment task.
5. Enable an online payment gateway such as Stripe. 
6. You should be redirected to `WooCommerce -> Home`
