### PR TITLE
Fix view logic for Setup additional payment providers task

### DIFF
--- a/changelogs/fix-extended-payments
+++ b/changelogs/fix-extended-payments
@@ -1,4 +1,4 @@
 Significance: patch
 Type: Fix
 
-Fix view logic for Setup additional payment providers task
+Fix view logic for Setup additional payment providers task. #8391

--- a/changelogs/fix-extended-payments
+++ b/changelogs/fix-extended-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix view logic for Setup additional payment providers task

--- a/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -37,8 +37,19 @@ class AdditionalPayments extends Payments {
 	 * @return bool
 	 */
 	public function can_view() {
+		if ( ! Features::is_enabled( 'payment-gateway-suggestions' ) ) {
+			// Hide task if feature not enabled.
+			return false;
+		}
+
 		$woocommerce_payments = new WooCommercePayments();
-		return Features::is_enabled( 'payment-gateway-suggestions' ) && $woocommerce_payments->can_view();
+
+		if ( $woocommerce_payments->is_requested() && $woocommerce_payments->is_supported() && ! $woocommerce_payments->is_connected() ) {
+			// Hide task if WC Pay is installed via OBW, in supported country, but not connected.
+			return false;
+		}
+
+		return true;
 	}
 }
 


### PR DESCRIPTION
Fixes #8315 

This PR updates the logic deciding whether to show the task "Setup payment providers".

Previously a bug existed where it would show incorrectly because it was directly relying on the `can_view` method from `WooCommercePayments`, which doesn't check the connection status.

This PR updates the logic so the task will **NOT** display when all of the following conditions met:

* WC Pay installed from Onboarding Wizard 
* The store’s country is supported 
* WC Pay is not set up (connected).



### Detailed test instructions:

- Start the onboarding wizard on a fresh install
- Choose a supported country like US
- Install WooCommerce Payments in the Business Details / Free Features step.
- Do not complete the WooCommerce Payments set up.

#### Case 1: WC Pay is not set up
- See that "Get paid with WooCommerce Payments" task is not ticked.
- See that "Setup additional payment providers" is not shown. 

<img width="529" alt="Screen Shot 2022-03-01 at 3 01 17 pm" src="https://user-images.githubusercontent.com/9312929/156120850-91dbffb9-04c8-4a9a-afa1-3430ed810ffa.png">

#### Case 2 WC Pay is set up
- Set up WooCommerce Payments or cheat by adding `return true` to `src/Features/OnboardingTasks/Tasks/WooCommercePayments.php` [line 128](https://github.com/woocommerce/woocommerce-admin/blob/25458963affe344f8740004ad09aa6a9927e4cb5/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php#L128)
- See that "Get paid with WooCommerce Payments" task is ticked.
- See that "Setup additional payment providers" is shown. 

<img width="526" alt="Screen Shot 2022-03-01 at 3 01 03 pm" src="https://user-images.githubusercontent.com/9312929/156121335-c4cfe575-9992-4896-a89d-444d1909548d.png">


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
