### PR TITLE
Use integers for add_menu_page priority

### DIFF
--- a/changelogs/fix-82910-add-menu-page-invalid-parameter
+++ b/changelogs/fix-82910-add-menu-page-invalid-parameter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix invalid parameter passed to add_menu_page() for wordpress >= 6.0. #8399

--- a/src-internal/Admin/Analytics.php
+++ b/src-internal/Admin/Analytics.php
@@ -186,7 +186,7 @@ class Analytics {
 			'title'    => __( 'Analytics', 'woocommerce-admin' ),
 			'path'     => '/analytics/overview',
 			'icon'     => 'dashicons-chart-bar',
-			'position' => 56, // After WooCommerce & Product menu items.
+			'position' => 57, // After WooCommerce & Product menu items.
 		);
 
 		$report_pages = array(

--- a/src-internal/Admin/WcPayWelcomePage.php
+++ b/src-internal/Admin/WcPayWelcomePage.php
@@ -72,7 +72,7 @@ class WcPayWelcomePage {
 				'admin.php?page=wc-admin&path=/wc-pay-welcome-page',
 				null,
 				$menu_icon,
-				55.7,
+				56,
 			);
 
 			call_user_func_array( 'add_menu_page', $menu_with_nav_data );

--- a/src-internal/Admin/WcPayWelcomePage.php
+++ b/src-internal/Admin/WcPayWelcomePage.php
@@ -48,7 +48,7 @@ class WcPayWelcomePage {
 			'id'       => 'wc-calypso-bridge-payments-welcome-page',
 			'title'    => __( 'Payments', 'woocommerce-admin' ),
 			'path'     => '/wc-pay-welcome-page',
-			'position' => '55.7',
+			'position' => '56',
 			'nav_args' => [
 				'title'        => __( 'WooCommerce Payments', 'woocommerce-admin' ),
 				'is_category'  => false,

--- a/src/PageController.php
+++ b/src/PageController.php
@@ -440,7 +440,7 @@ class PageController {
 				$options['path'],
 				array( __CLASS__, 'page_wrapper' ),
 				$options['icon'],
-				$options['position']
+				intval( round( $options['position'] ) )
 			);
 		} else {
 			$parent_path = $this->get_path_from_id( $options['parent'] );


### PR DESCRIPTION
Fixes #8291

In wordpress >= 6.0, the seventh parameter passed to `add_menu_page()` should be an integer representing menu position.

![image](https://user-images.githubusercontent.com/27843274/155068523-892b56f8-016d-4ccf-a55f-2fd27959f906.png)

### Detailed test instructions:


1. Clone a copy of [latest Wordpress](https://github.com/WordPress/WordPress/), take note of the path that you cloned it to.
2. Make a copy of `.wp-env.json` and name it `.wp-env.override.json`
3. Change the value of the key "core" to the path of the Wordpress install above and use `Nightly` woocommerce, e.g:

```
{
	"phpVersion": "7.4",
	"core": "<replace-with-wordpress-path>",
	"plugins": [
		".",
		"https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip"
	],
	"config": {
		"JETPACK_AUTOLOAD_DEV": true,
		"WP_DEBUG_LOG": true,
		"WP_DEBUG_DISPLAY": true,
		"ALTERNATE_WP_CRON": true
	}
}
```
 We need to use Nightly WooCommerce core because the `class-wc-admin-menus.php` has been fixed in [this commit](https://github.com/woocommerce/woocommerce/commit/de57b39d8ec7afb76cd11fc52c8b81cd753ede66) for the same error, but not release yet.

4. Start the site and go to **WooCommerce > Home**
5. Should no errors and menus be added properly.



<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
