### PR TITLE
Fix long notes are not replaced with shorter notes

### DIFF
--- a/changelogs/fix-8008-long-notes-are-not-replaced-with-shorter-notes
+++ b/changelogs/fix-8008-long-notes-are-not-replaced-with-shorter-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Add 'possibly_update_note' to replace long notes with shorter notes. #8401

--- a/src-internal/Admin/Events.php
+++ b/src-internal/Admin/Events.php
@@ -92,6 +92,7 @@ class Events {
 	public function do_wc_admin_daily() {
 		$this->possibly_add_notes();
 		$this->possibly_delete_notes();
+		$this->possibly_update_notes();
 
 		if ( $this->is_remote_inbox_notifications_enabled() ) {
 			DataSourcePoller::get_instance()->read_specs_from_data_sources();
@@ -151,6 +152,43 @@ class Events {
 		NavigationNudge::delete_if_not_applicable();
 		SetUpAdditionalPaymentTypes::delete_if_not_applicable();
 		PaymentsRemindMeLater::delete_if_not_applicable();
+	}
+
+	/**
+	 * Updates notes that should be updated.
+	 */
+	protected function possibly_update_notes() {
+		NewSalesRecord::possibly_update_note();
+		MobileApp::possibly_update_note();
+		TrackingOptIn::possibly_update_note();
+		OnboardingPayments::possibly_update_note();
+		PersonalizeStore::possibly_update_note();
+		WooCommercePayments::possibly_update_note();
+		EUVATNumber::possibly_update_note();
+		MarketingJetpack::possibly_update_note();
+		WooCommerceSubscriptions::possibly_update_note();
+		MigrateFromShopify::possibly_update_note();
+		InsightFirstSale::possibly_update_note();
+		LaunchChecklist::possibly_update_note();
+		OnlineClothingStore::possibly_update_note();
+		FirstProduct::possibly_update_note();
+		RealTimeOrderAlerts::possibly_update_note();
+		CustomizeStoreWithBlocks::possibly_update_note();
+		TestCheckout::possibly_update_note();
+		EditProductsOnTheMove::possibly_update_note();
+		PerformanceOnMobile::possibly_update_note();
+		ManageOrdersOnTheGo::possibly_update_note();
+		ChoosingTheme::possibly_update_note();
+		InsightFirstProductAndPayment::possibly_update_note();
+		AddFirstProduct::possibly_update_note();
+		AddingAndManangingProducts::possibly_update_note();
+		CustomizingProductCatalog::possibly_update_note();
+		FirstDownlaodableProduct::possibly_update_note();
+		NavigationNudge::possibly_update_note();
+		CompleteStoreDetails::possibly_update_note();
+		UpdateStoreDetails::possibly_update_note();
+		PaymentsRemindMeLater::possibly_update_note();
+		MagentoMigration::possibly_update_note();
 	}
 
 	/**

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -143,6 +143,33 @@ trait NoteTraits {
 		}
 	}
 
+
+	/**
+	 * Update the note if it passes predefined conditions.
+	 *
+	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
+	 */
+	public static function possibly_update_note() {
+		$data_store = Notes::load_data_store();
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = Notes::get_note( $note_ids[0] );
+		if ( ! $note ) {
+			return;
+		}
+
+		// Update note content if it's changed.
+		$latest_note_content = self::get_note()->get_content();
+		if ( $note->get_content() !== $latest_note_content ) {
+			$note->set_content( $latest_note_content );
+			$note->save();
+		}
+	}
+
 	/**
 	 * Get if the note has been actioned.
 	 *

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -150,14 +150,8 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function possibly_update_note() {
-		$data_store = Notes::load_data_store();
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		$note = Notes::get_note_by_name( self::NOTE_NAME );
 
-		if ( empty( $note_ids ) ) {
-			return;
-		}
-
-		$note = Notes::get_note( $note_ids[0] );
 		if ( ! $note ) {
 			return;
 		}
@@ -169,7 +163,6 @@ trait NoteTraits {
 			$note->save();
 		}
 	}
-
 	/**
 	 * Get if the note has been actioned.
 	 *

--- a/tests/notes/class-wc-tests-note-traits.php
+++ b/tests/notes/class-wc-tests-note-traits.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
 use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
@@ -98,6 +97,11 @@ class WC_Tests_NoteTraits extends WC_Unit_Test_Case {
 			array(
 				function () {
 					self::possibly_delete_note();
+				},
+			),
+			array(
+				function () {
+					self::possibly_update_note();
 				},
 			),
 			array(


### PR DESCRIPTION
Fixes woocommerce/woocommerce-admin#8008

Add `possibly_update_note` to replace long notes with shorter notes

### Detailed test instructions:

1. Update `woocommerce_admin_install_timestamp` option value to 3 days ago. Get this timestamp on macOS with `date -v-3d +"%s"`.
2. Delete the Install Woo mobile app note in the database. `delete from wp_wc_admin_notes where name = 'wc-admin-mobile-app';`
3. Modify `src/Notes/MobileApp.php` note content to have more than 320 characters.
4. Install `WP Crontrol` and Run the `wc_admin_daily` cron event.
5. See that the note is truncated on Home Screen.
6. Restore `src/Notes/MobileApp.php` to the original content.
7. Run the `wc_admin_daily` cron event.
8. See that the note is updated to the original content.




<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
