### PR TITLE
Fix inbox letters truncator to support multi characters

### DIFF
--- a/changelogs/fix-8005-multi-characters-inbox-letters-truncator
+++ b/changelogs/fix-8005-multi-characters-inbox-letters-truncator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix inbox letters truncator to support multi characters. #8404

--- a/client/inbox-panel/index.js
+++ b/client/inbox-panel/index.js
@@ -20,6 +20,7 @@ import {
 	Text,
 } from '@woocommerce/experimental';
 import moment from 'moment';
+
 /**
  * Internal dependencies
  */
@@ -211,10 +212,13 @@ const InboxPanel = ( { showHeader = true } ) => {
 						supportedLocales.includes( note.locale ) &&
 						noteDate >= WC_VERSION_61_RELEASE_DATE
 					) {
-						note.content = truncateRenderableHTML(
-							note.content,
-							320
-						);
+						return {
+							...note,
+							content: truncateRenderableHTML(
+								note.content,
+								320
+							),
+						};
 					}
 					return note;
 				} ),

--- a/client/inbox-panel/test/utils.js
+++ b/client/inbox-panel/test/utils.js
@@ -65,12 +65,12 @@ describe( 'truncateRenderableHTML', () => {
 	test( 'it should work with multi-char letters', () => {
 		const sampleWithUnicode = '<div>🏳️‍🌈</div>';
 		expect( truncateRenderableHTML( sampleWithUnicode, 1 ) ).toBe(
-			'<div>🏳️‍🌈</div>...'
+			'<div>🏳️‍🌈</div>'
 		);
 
 		const hindiSample = '<div>अनुच्छेद</div>';
 		expect( truncateRenderableHTML( hindiSample, 5 ) ).toBe(
-			'<div>अनुच्छेद</div>...'
+			'<div>अनुच्छेद</div>'
 		);
 
 		expect( truncateRenderableHTML( hindiSample, 3 ) ).toBe(
@@ -79,7 +79,7 @@ describe( 'truncateRenderableHTML', () => {
 
 		const demonicSample = '<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>';
 		expect( truncateRenderableHTML( demonicSample, 6 ) ).toBe(
-			'<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>...'
+			'<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>'
 		);
 	} );
 } );

--- a/client/inbox-panel/test/utils.js
+++ b/client/inbox-panel/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { truncateRenderableHTML } from '../utils';
+import { truncateRenderableHTML, truncate } from '../utils';
 
 describe( 'truncateRenderableHTML', () => {
 	test( 'it should recover malformed HTML when truncated', () => {
@@ -88,6 +88,30 @@ describe( 'truncateRenderableHTML', () => {
 		const demonicSample = '<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>';
 		expect( truncateRenderableHTML( demonicSample, 6 ) ).toBe(
 			'<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>'
+		);
+	} );
+} );
+
+describe( 'truncate', () => {
+	it( 'should truncate letters and return truncated string', () => {
+		expect( truncate( 'this is a test sentence'.split( '' ), 4 ) ).toBe(
+			'this'
+		);
+	} );
+
+	it( 'should not contain end-space', () => {
+		expect( truncate( 'this is a test sentence'.split( '' ), 5 ) ).toBe(
+			'this'
+		);
+	} );
+
+	it( 'should preserve whole words', () => {
+		// "this i" doesn't preserve whole words, so it should be truncated to "this"
+		expect( truncate( 'this is a test sentence'.split( '' ), 6 ) ).toBe(
+			'this'
+		);
+		expect( truncate( 'this is a test sentence'.split( '' ), 7 ) ).toBe(
+			'this is'
 		);
 	} );
 } );

--- a/client/inbox-panel/test/utils.js
+++ b/client/inbox-panel/test/utils.js
@@ -35,6 +35,14 @@ describe( 'truncateRenderableHTML', () => {
 		);
 	} );
 
+	test( 'it should truncate properly with nested tags', () => {
+		const sampleWithNestedTags = '<div>this is <div>a</div></div>';
+		// this (4 chars) + space (1 char) + is (2char) + space (1 char) = 7
+		expect( truncateRenderableHTML( sampleWithNestedTags, 7 ) ).toBe(
+			'<div>this is</div>...'
+		);
+	} );
+
 	test( 'it should work with unicode text', () => {
 		const sampleWithUnicode = '<div>테스트 입니다.</div>';
 		expect( truncateRenderableHTML( sampleWithUnicode, 3 ) ).toBe(

--- a/client/inbox-panel/test/utils.js
+++ b/client/inbox-panel/test/utils.js
@@ -51,4 +51,35 @@ describe( 'truncateRenderableHTML', () => {
 			'<div>this is a</div>...'
 		);
 	} );
+
+	test( 'it should preserve whole words with emoji when truncated', () => {
+		const sample = '<div>🏳️‍🌈this is a test sentence</div>';
+		// it should return '🏳️‍🌈this is a' (10 chars) when length 12 is given
+		// since '🏳️‍🌈this is a t' (12 chars) cannot include 'test' word without
+		// breaking the word.
+		expect( truncateRenderableHTML( sample, 12 ) ).toBe(
+			'<div>🏳️‍🌈this is a</div>...'
+		);
+	} );
+
+	test( 'it should work with multi-char letters', () => {
+		const sampleWithUnicode = '<div>🏳️‍🌈</div>';
+		expect( truncateRenderableHTML( sampleWithUnicode, 1 ) ).toBe(
+			'<div>🏳️‍🌈</div>...'
+		);
+
+		const hindiSample = '<div>अनुच्छेद</div>';
+		expect( truncateRenderableHTML( hindiSample, 5 ) ).toBe(
+			'<div>अनुच्छेद</div>...'
+		);
+
+		expect( truncateRenderableHTML( hindiSample, 3 ) ).toBe(
+			'<div>अनुच्</div>...'
+		);
+
+		const demonicSample = '<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>';
+		expect( truncateRenderableHTML( demonicSample, 6 ) ).toBe(
+			'<div>Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞</div>...'
+		);
+	} );
 } );

--- a/client/inbox-panel/utils.js
+++ b/client/inbox-panel/utils.js
@@ -119,8 +119,10 @@ const truncateElement = ( element, limit ) => {
  */
 export const truncateRenderableHTML = ( originalHTML, limit ) => {
 	const tempNode = document.createElement( 'div' );
+	const splitter = new GraphemeSplitter();
+
 	tempNode.innerHTML = originalHTML;
-	if ( tempNode.textContent.length > limit ) {
+	if ( splitter.splitGraphemes( tempNode.textContent ).length > limit ) {
 		return truncateElement( tempNode, limit ).innerHTML + '...';
 	}
 	return originalHTML;

--- a/client/inbox-panel/utils.js
+++ b/client/inbox-panel/utils.js
@@ -50,7 +50,7 @@ export function hasValidNotes( notes ) {
  * @param {number} limit number of characters to limit to
  * @param {string} separator The separator string to truncate to.
  */
-const truncate = ( letters, limit, separator = ' ' ) => {
+export const truncate = ( letters, limit, separator = ' ' ) => {
 	let truncatedLetters = letters.slice( 0, limit );
 
 	if ( letters.indexOf( separator, limit ) !== limit ) {
@@ -89,20 +89,13 @@ const truncateElement = ( element, limit ) => {
 		}
 
 		const charactersRemaining = limit - truncatedTextLength;
-		const isNodeOnlyTextContent =
-			! clone.innerHTML ||
-			clone.textContent.slice( 0, charactersRemaining ) ===
-				clone.innerHTML.slice( 0, charactersRemaining );
-
-		if ( isNodeOnlyTextContent ) {
-			// If text until the limit doesn't contain any markup, we're all good to truncate.
+		if ( clone.hasChildNodes() ) {
+			clone = truncateElement( clone, charactersRemaining );
+		} else {
 			clone.textContent = truncate(
 				cloneNodeLetters,
 				charactersRemaining
 			);
-		} else {
-			// If it does, then we'd need to recursively run this with balance of characters remaining.
-			clone = truncateElement( clone, charactersRemaining );
 		}
 		truncatedNode.appendChild( clone );
 		// Exceeded limit at this point, safe to exit loop.

--- a/client/inbox-panel/utils.js
+++ b/client/inbox-panel/utils.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { filter, truncate } from 'lodash';
+import { filter } from 'lodash';
+import GraphemeSplitter from 'grapheme-splitter';
 
 /**
  * Get the count of the unread notes from the received list.
@@ -43,6 +44,26 @@ export function hasValidNotes( notes ) {
 }
 
 /**
+ * Truncates array of text characters.
+ *
+ * @param {Array} letters The letter array to truncate.
+ * @param {number} limit number of characters to limit to
+ * @param {string} separator The separator string to truncate to.
+ */
+const truncate = ( letters, limit, separator = ' ' ) => {
+	let truncatedLetters = letters.slice( 0, limit );
+
+	if ( letters.indexOf( separator, limit ) !== limit ) {
+		// If there's a space in the text, we need to truncate at the space to preserve whole words.
+		const index = truncatedLetters.lastIndexOf( separator );
+		if ( index > -1 ) {
+			truncatedLetters = truncatedLetters.slice( 0, index );
+		}
+	}
+	return truncatedLetters.join( '' );
+};
+
+/**
  * Truncates characters inside of an element.
  * Currently does not count <br> as a character even though it should.
  *
@@ -52,37 +73,40 @@ export function hasValidNotes( notes ) {
 const truncateElement = ( element, limit ) => {
 	const truncatedNode = document.createElement( 'div' );
 	const childNodes = Array.from( element.childNodes );
+	const splitter = new GraphemeSplitter();
+	let truncatedTextLength = 0;
+
 	for ( let i = 0; i < childNodes.length; i++ ) {
 		// Deep clone.
 		let clone = childNodes[ i ].cloneNode( true );
-		if (
-			truncatedNode.textContent.length + clone.textContent.length <=
-			limit
-		) {
+		const cloneNodeLetters = splitter.splitGraphemes( clone.textContent );
+
+		if ( truncatedTextLength + cloneNodeLetters.length <= limit ) {
 			// No problem including a whole child node, no need to consider truncating at all.
 			truncatedNode.appendChild( clone );
-		} else {
-			const charactersRemaining =
-				limit - truncatedNode.textContent.length;
-			if (
-				! clone.innerHTML ||
-				clone.textContent.slice( 0, charactersRemaining ) ===
-					clone.innerHTML.slice( 0, charactersRemaining )
-			) {
-				// If text until the limit doesn't contain any markup, we're all good to truncate.
-				clone.textContent = truncate( clone.textContent, {
-					length: charactersRemaining,
-					separator: ' ',
-					omission: '',
-				} );
-			} else {
-				// If it does, then we'd need to recursively run this with balance of characters remaining.
-				clone = truncateElement( clone, charactersRemaining );
-			}
-			truncatedNode.appendChild( clone );
-			// Exceeded limit at this point, safe to exit loop.
-			break;
+			truncatedTextLength += cloneNodeLetters.length;
+			continue;
 		}
+
+		const charactersRemaining = limit - truncatedTextLength;
+		const isNodeOnlyTextContent =
+			! clone.innerHTML ||
+			clone.textContent.slice( 0, charactersRemaining ) ===
+				clone.innerHTML.slice( 0, charactersRemaining );
+
+		if ( isNodeOnlyTextContent ) {
+			// If text until the limit doesn't contain any markup, we're all good to truncate.
+			clone.textContent = truncate(
+				cloneNodeLetters,
+				charactersRemaining
+			);
+		} else {
+			// If it does, then we'd need to recursively run this with balance of characters remaining.
+			clone = truncateElement( clone, charactersRemaining );
+		}
+		truncatedNode.appendChild( clone );
+		// Exceeded limit at this point, safe to exit loop.
+		break;
 	}
 	return truncatedNode;
 };

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
 		"debug": "4.3.1",
 		"dompurify": "2.2.9",
 		"github-label-sync": "2.0.0",
+		"grapheme-splitter": "^1.0.4",
 		"gridicons": "3.4.0",
 		"history": "4.10.1",
 		"lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,7 @@ importers:
       fork-ts-checker-webpack-plugin: 6.2.10
       fs-extra: 8.1.0
       github-label-sync: 2.0.0
+      grapheme-splitter: ^1.0.4
       gridicons: 3.4.0
       grunt: 1.3.0
       grunt-checktextdomain: 1.0.1
@@ -224,6 +225,7 @@ importers:
       debug: 4.3.1
       dompurify: 2.2.9
       github-label-sync: 2.0.0
+      grapheme-splitter: 1.0.4
       gridicons: 3.4.0_react@17.0.2
       history: 4.10.1
       lodash: 4.17.21
@@ -13473,6 +13475,10 @@ packages:
   /gradient-parser/0.1.5:
     resolution: {integrity: sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /grapheme-splitter/1.0.4:
+    resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: false
 
   /gridicons/3.4.0_react@17.0.2:


### PR DESCRIPTION
Fixes #8005

This PR updates the inbox notes HTML truncator to support multi-characters.

- Added [grapheme-splitter](https://github.com/orling/grapheme-splitter) to `package.json`

### Screenshots

![Screen Shot 2022-03-03 at 17 05 59](https://user-images.githubusercontent.com/4344253/156534353-11d89d7d-03a6-4de4-b291-8d0cb8761521.png)

![Screen Shot 2022-03-03 at 17 16 42](https://user-images.githubusercontent.com/4344253/156534372-cd332a07-d845-4f68-9c8f-e22fb3a1a4a3.png)


### Detailed test instructions:

- Change `wc-admin-wc-helper-connection` note (`src/Notes/WooSubscriptionsNotes.php`) content to 

--


`Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!͖̬̰̙̗̿̋ͥͥ̂ͣ̐́́͜͞Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘!̿̋ͥ`


--363 length in js

- Use a fresh site
- Go to WooCommerce > Home
- You should see the "Connect to WooCommerce.com" note with the content above without being truncated.
- Update note content in db table `wp_wc_admin_notes`with the results of `'🌷🎁😜👍🏳️‍🌈'.repeat(70)`
- You should see the truncated note.


<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `npm run changelogger -- add` and commit changes. --->
