### PR TITLE
Fix build "docs"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"clean": "rimraf ./dist && pnpm run:packages -- clean --parallel",
 		"predev": "pnpm run -s install-if-deps-outdated && php ./bin/update-version.php",
 		"dev": "cross-env WC_ADMIN_PHASE=development pnpm run build:feature-config && cross-env WC_ADMIN_PHASE=development pnpm run build:packages && cross-env WC_ADMIN_PHASE=development webpack",
-		"docs": "./bin/import-wp-css-storybook.sh && STORYBOOK=true pnpm exec build-storybook -c storybook/.storybook -o ./docs/components/storybook",
+		"docs": "./bin/import-wp-css-storybook.sh && BABEL_ENV=storybook STORYBOOK=true pnpm exec build-storybook -c storybook/.storybook -o ./docs/components/storybook",
 		"i18n": "pnpm run -s i18n:js && pnpm run -s i18n:check && pnpm run -s i18n:pot && pnpm run -s i18n:build",
 		"i18n:build": "php bin/combine-pot-files.php languages/woocommerce-admin.po languages/woocommerce-admin.pot",
 		"i18n:check": "grunt checktextdomain",


### PR DESCRIPTION
Fixes the [failing "docs" build](https://github.com/woocommerce/woocommerce-admin/runs/5417372927?check_suite_focus=true) after the pnpm PR https://github.com/woocommerce/woocommerce-admin/pull/8349 was merged.

We need to build the docs with the `BABEL_ENV=storybook`.

### Detailed test instructions:

- Should able to run `pnpm run docs` without errors

no changelog