### PR TITLE
Reintroduce emphasis on inbox note action button

### DIFF
--- a/changelogs/fix-84080-reintroduce-emphasis-on-inbox-note-action-button
+++ b/changelogs/fix-84080-reintroduce-emphasis-on-inbox-note-action-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Reintroduce emphasis on inbox note action button. #8411

--- a/packages/experimental/src/inbox-note/action.tsx
+++ b/packages/experimental/src/inbox-note/action.tsx
@@ -9,6 +9,7 @@ type InboxNoteActionProps = {
 	label: string;
 	href?: string;
 	preventBusyState?: boolean;
+	variant: 'link' | 'secondary';
 };
 
 /**
@@ -20,6 +21,7 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 	onClick,
 	href,
 	preventBusyState,
+	variant = 'link',
 } ) => {
 	const [ inAction, setInAction ] = useState( false );
 
@@ -53,7 +55,8 @@ export const InboxNoteActionButton: React.FC< InboxNoteActionProps > = ( {
 
 	return (
 		<Button
-			isLink={ true }
+			isSecondary={ variant === 'secondary' }
+			isLink={ variant === 'link' }
 			isBusy={ inAction }
 			disabled={ inAction }
 			href={ href }

--- a/packages/experimental/src/inbox-note/inbox-note.tsx
+++ b/packages/experimental/src/inbox-note/inbox-note.tsx
@@ -128,6 +128,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 					<InboxNoteActionButton
 						key={ action.id }
 						label={ action.label }
+						variant="secondary"
 						href={
 							action && action.url && action.url.length
 								? action.url
@@ -198,6 +199,7 @@ const InboxNoteCard: React.FC< InboxNoteProps > = ( {
 									key={ note.actions[ 0 ].id }
 									label={ title }
 									preventBusyState={ true }
+									variant="link"
 									href={
 										note.actions[ 0 ].url &&
 										note.actions[ 0 ].url.length

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -36,9 +36,6 @@
 				font-weight: normal;
 			}
 		}
-		.woocommerce-inbox-message__actions a {
-			color: $gray-900;
-		}
 	}
 
 	.woocommerce-homepage-column & {

--- a/packages/experimental/src/inbox-note/style.scss
+++ b/packages/experimental/src/inbox-note/style.scss
@@ -192,7 +192,7 @@
 		}
 	}
 }
-.woocommerce-inbox-message__wrapper .woocommerce-inbox-message__actions {
+.woocommerce-inbox-message__wrapper {
 	padding-top: 0;
 }
 


### PR DESCRIPTION
Fixes #8408

Reintroduce emphasis (blue border style) on the inbox note action button.


`InboxNoteActionButton` component is used for both note title and note action so we need to have different styles for them (`link` & `secondary`).


### Screenshots

![Screen Shot 2022-03-04 at 16 03 41](https://user-images.githubusercontent.com/4344253/156723923-92219333-45c4-43b2-9294-ad79546babb7.png)


### Detailed test instructions:

1. Checkout this branch
2. Go to WooCommerce > Home
3. Should see the blue border styled note action buttons.


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
