### PR TITLE
Fix paid themes

### DIFF
--- a/changelogs/fix-8397_fix_paid_themes
+++ b/changelogs/fix-8397_fix_paid_themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Make sure the paid extension task is also shown for themes. #8412

--- a/src/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/src/Features/OnboardingTasks/Tasks/Purchase.php
@@ -147,6 +147,7 @@ class Purchase extends Task {
 	 */
 	private function get_price_from_string( $price_string ) {
 		$price_match = null;
+		// Parse price from string as it includes the currency symbol.
 		preg_match( '/\\d+\.\d{2}\s*/', $price_string, $price_match );
 		if ( count( $price_match ) > 0 ) {
 			return (float) $price_match[0];

--- a/src/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/src/Features/OnboardingTasks/Tasks/Purchase.php
@@ -150,17 +150,18 @@ class Purchase extends Task {
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 		$product_data  = Onboarding::get_product_data( Onboarding::get_allowed_product_types() );
 		$themes        = Onboarding::get_themes();
-		$theme_key     = array_search( $profiler_data['theme'], array_column($themes, 'slug') );
+		$theme_key     = array_search( $profiler_data['theme'], array_column( $themes, 'slug' ), true );
 		if ( false !== $theme_key && isset( $themes[ $theme_key ]['id'] ) && isset( $themes[ $theme_key ]['price'] ) && ! $themes[ $theme_key ]['is_installed'] ) {
 			$price_match = null;
-			preg_match( '/\\d+\.\d{2}\s*/',  $themes[ $theme_key ]['price'], $price_match);
+			// Find the price inside the string as it contains other items.
+			preg_match( '/\\d+\.\d{2}\s*/', $themes[ $theme_key ]['price'], $price_match );
 			if ( count( $price_match ) > 0 && ( (float) $price_match[0] ) > 0 ) {
-				$product_types[] = 'themes';
-				$product_data['themes'] = $themes[$theme_key];
+				$product_types[]        = 'themes';
+				$product_data['themes'] = $themes[ $theme_key ];
 			}
 		}
-		$purchaseable  = array();
-		$remaining     = array();
+		$purchaseable = array();
+		$remaining    = array();
 		foreach ( $product_types as $type ) {
 			if ( ! isset( $product_data[ $type ]['slug'] ) ) {
 				continue;
@@ -170,9 +171,9 @@ class Purchase extends Task {
 
 			if ( ! in_array( $product_data[ $type ]['slug'], $installed, true ) ) {
 				if ( isset( $product_data[ $type ]['label'] ) ) {
-					$remaining[] = $product_data[$type]['label'];
+					$remaining[] = $product_data[ $type ]['label'];
 				} else {
-					$remaining[] = $product_data[$type]['title'];
+					$remaining[] = $product_data[ $type ]['title'];
 				}
 			}
 		}

--- a/src/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/src/Features/OnboardingTasks/Tasks/Purchase.php
@@ -149,6 +149,16 @@ class Purchase extends Task {
 		$installed     = PluginsHelper::get_installed_plugin_slugs();
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 		$product_data  = Onboarding::get_product_data( Onboarding::get_allowed_product_types() );
+		$themes        = Onboarding::get_themes();
+		$theme_key     = array_search( $profiler_data['theme'], array_column($themes, 'slug') );
+		if ( false !== $theme_key && isset( $themes[ $theme_key ]['id'] ) && isset( $themes[ $theme_key ]['price'] ) && ! $themes[ $theme_key ]['is_installed'] ) {
+			$price_match = null;
+			preg_match( '/\\d+\.\d{2}\s*/',  $themes[ $theme_key ]['price'], $price_match);
+			if ( count( $price_match ) > 0 && ( (float) $price_match[0] ) > 0 ) {
+				$product_types[] = 'themes';
+				$product_data['themes'] = $themes[$theme_key];
+			}
+		}
 		$purchaseable  = array();
 		$remaining     = array();
 		foreach ( $product_types as $type ) {
@@ -159,7 +169,11 @@ class Purchase extends Task {
 			$purchaseable[] = $product_data[ $type ];
 
 			if ( ! in_array( $product_data[ $type ]['slug'], $installed, true ) ) {
-				$remaining[] = $product_data[ $type ]['label'];
+				if ( isset( $product_data[ $type ]['label'] ) ) {
+					$remaining[] = $product_data[$type]['label'];
+				} else {
+					$remaining[] = $product_data[$type]['title'];
+				}
 			}
 		}
 

--- a/src/Features/OnboardingTasks/Tasks/Purchase.php
+++ b/src/Features/OnboardingTasks/Tasks/Purchase.php
@@ -53,7 +53,7 @@ class Purchase extends Task {
 	 * @return string
 	 */
 	public function get_title() {
-		$products = self::get_products();
+		$products = $this->get_products();
 
 		return count( $products['remaining'] ) === 1
 			? sprintf(
@@ -76,7 +76,7 @@ class Purchase extends Task {
 	 * @return string
 	 */
 	public function get_content() {
-		$products = self::get_products();
+		$products = $this->get_products();
 
 		return count( $products['remaining'] ) === 1
 			? $products['purchaseable'][0]['description']
@@ -116,7 +116,7 @@ class Purchase extends Task {
 	 * @return bool
 	 */
 	public function is_complete() {
-		$products = self::get_products();
+		$products = $this->get_products();
 		return count( $products['remaining'] ) === 0;
 	}
 
@@ -135,8 +135,42 @@ class Purchase extends Task {
 	 * @return bool
 	 */
 	public function can_view() {
-		$products = self::get_products();
+		$products = $this->get_products();
 		return count( $products['purchaseable'] ) > 0;
+	}
+
+	/**
+	 * Get puchasable theme by slug.
+	 *
+	 * @param string $price_string string of price.
+	 * @return float|null
+	 */
+	private function get_price_from_string( $price_string ) {
+		$price_match = null;
+		preg_match( '/\\d+\.\d{2}\s*/', $price_string, $price_match );
+		if ( count( $price_match ) > 0 ) {
+			return (float) $price_match[0];
+		}
+		return null;
+	}
+
+	/**
+	 * Get puchasable theme by slug.
+	 *
+	 * @param string $slug from theme.
+	 * @return array|null
+	 */
+	private function get_paid_theme_by_slug( $slug ) {
+		$themes    = Onboarding::get_themes();
+		$theme_key = array_search( $slug, array_column( $themes, 'slug' ), true );
+		$theme     = false !== $theme_key ? $themes[ $theme_key ] : null;
+		if ( $theme && isset( $theme['id'] ) && isset( $theme['price'] ) && ( ! isset( $theme['is_installed'] ) || ! $theme['is_installed'] ) ) {
+			$price = $this->get_price_from_string( $theme['price'] );
+			if ( $price && $price > 0 ) {
+				return $themes[ $theme_key ];
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -144,22 +178,19 @@ class Purchase extends Task {
 	 *
 	 * @return array
 	 */
-	public static function get_products() {
+	private function get_products() {
 		$profiler_data = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$installed     = PluginsHelper::get_installed_plugin_slugs();
 		$product_types = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 		$product_data  = Onboarding::get_product_data( Onboarding::get_allowed_product_types() );
-		$themes        = Onboarding::get_themes();
-		$theme_key     = array_search( $profiler_data['theme'], array_column( $themes, 'slug' ), true );
-		if ( false !== $theme_key && isset( $themes[ $theme_key ]['id'] ) && isset( $themes[ $theme_key ]['price'] ) && ! $themes[ $theme_key ]['is_installed'] ) {
-			$price_match = null;
-			// Find the price inside the string as it contains other items.
-			preg_match( '/\\d+\.\d{2}\s*/', $themes[ $theme_key ]['price'], $price_match );
-			if ( count( $price_match ) > 0 && ( (float) $price_match[0] ) > 0 ) {
-				$product_types[]        = 'themes';
-				$product_data['themes'] = $themes[ $theme_key ];
-			}
+
+		$theme      = isset( $profiler_data['theme'] ) ? $profiler_data['theme'] : null;
+		$paid_theme = $theme ? $this->get_paid_theme_by_slug( $theme ) : null;
+		if ( $paid_theme ) {
+			$product_types[]        = 'themes';
+			$product_data['themes'] = $paid_theme;
 		}
+
 		$purchaseable = array();
 		$remaining    = array();
 		foreach ( $product_types as $type ) {

--- a/tests/features/onboarding-tasks/tasks/purchase.php
+++ b/tests/features/onboarding-tasks/tasks/purchase.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Test the TaskList class.
+ *
+ * @package WooCommerce\Admin\Tests\OnboardingTasks
+ */
+
+use Automattic\WooCommerce\Admin\Features\Onboarding;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskList;
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks\Purchase;
+
+/**
+ * class WC_Tests_OnboardingTasks_TaskList
+ */
+class WC_Tests_OnboardingTasks_Task_Purchase extends WC_Unit_Test_Case {
+
+	/**
+	 * Task list.
+	 *
+	 * @var Task|null
+	 */
+	protected $task = null;
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->task = new Purchase( new TaskList() );
+		set_transient(
+			Onboarding::THEMES_TRANSIENT,
+			array(
+				'free'            => array( 'slug' => 'free' ),
+				'paid'            => array(
+					'slug'  => 'paid',
+					'id'    => 12312,
+					'price' => '&#36;79.00',
+					'title' => 'theme title',
+				),
+				'paid_installed'  => array(
+					'slug'         => 'paid_installed',
+					'id'           => 12312,
+					'price'        => '&#36;79.00',
+					'title'        => 'theme title',
+					'is_installed' => true,
+				),
+				'free_with_price' => array(
+					'slug'  => 'free_with_price',
+					'id'    => 12312,
+					'price' => '&#36;0.00',
+					'title' => 'theme title',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		delete_transient( Onboarding::THEMES_TRANSIENT );
+		delete_option( Onboarding::PROFILE_DATA_OPTION );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_complete_if_no_remaining_products() {
+		update_option( Onboarding::PROFILE_DATA_OPTION, array( 'product_types' => array( 'physical' ) ) );
+		$this->assertEquals( true, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_not_complete_if_remaining_paid_products() {
+		update_option( Onboarding::PROFILE_DATA_OPTION, array( 'product_types' => array( 'memberships' ) ) );
+		$this->assertEquals( false, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_complete_if_no_paid_themes() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array(),
+				'theme'         => 'free',
+			)
+		);
+		$this->assertEquals( true, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_not_complete_if_paid_theme_that_is_not_installed() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array(),
+				'theme'         => 'paid',
+			)
+		);
+		$this->assertEquals( false, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_complete_if_paid_theme_that_is_installed() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array(),
+				'theme'         => 'paid_installed',
+			)
+		);
+		$this->assertEquals( true, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_is_complete_if_free_theme_with_set_price() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array(),
+				'theme'         => 'free_with_price',
+			)
+		);
+		$this->assertEquals( true, $this->task->is_complete() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_get_title_if_single_paid_item() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array(),
+				'theme'         => 'paid',
+			)
+		);
+		$this->assertEquals( 'Add theme title to my store', $this->task->get_title() );
+	}
+
+	/**
+	 * Test is_complete function of Purchase task.
+	 */
+	public function test_get_title_if_multiple_paid_themes() {
+		update_option(
+			Onboarding::PROFILE_DATA_OPTION,
+			array(
+				'product_types' => array( 'memberships' ),
+				'theme'         => 'paid',
+			)
+		);
+		$this->assertEquals( 'Add paid extensions to my store', $this->task->get_title() );
+	}
+}


### PR DESCRIPTION
Fixes #8397 

This fixes the payments task, to also handle paid themes. This was accidentally removed when moving the task logic to the back end.

### Screenshots

<img width="1071" alt="Screen Shot 2022-03-04 at 10 45 09 AM" src="https://user-images.githubusercontent.com/2240960/156784055-9855a4ab-f4ee-4a05-8df0-56fbbab09372.png">

### Detailed test instructions:

- Go to 'Setup Wizard'
- Click on 'Themes / Choose' and select a paid theme
- This will take you back to the home screen
- Notice a `Add <theme name> to my store` task
- Click on this task, this should show the theme and allow you to buy it
- Go back to the 'Setup wizard' and under 'Product Types' select a paid product type ( like Memberships )
- Finish the onboarding wizard and still selecting a paid theme at the end
- The task should now say `Add paid extensions to my store` and list all the paid extensions the user has selected (in this case Memberships and the selected theme).

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
