### PR TITLE
Use update_option instead of delete_option + add_option

### DIFF
--- a/src-internal/Admin/Install.php
+++ b/src-internal/Admin/Install.php
@@ -514,8 +514,7 @@ class Install {
 	 * @param string|null $version New WooCommerce Admin DB version or null.
 	 */
 	public static function update_db_version( $version = null ) {
-		delete_option( self::VERSION_OPTION );
-		add_option( self::VERSION_OPTION, is_null( $version ) ? WC_ADMIN_VERSION_NUMBER : $version );
+		update_option( self::VERSION_OPTION, is_null( $version ) ? WC_ADMIN_VERSION_NUMBER : $version );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8420

This PR uses `update_option` instead of `delete_option` then `add_option` to help some race conditions in the install class. More details [here](https://github.com/woocommerce/woocommerce/pull/27696)


### Detailed test instructions:

1. Lower value of `woocommerce_admin_version` option from `wp_options`
2. Access your website.
3. Confirm `woocommerce_admin_version` updates to the latest version. 

no changelog