### PR TITLE
Translate dates in NewSalesRecord note

### DIFF
--- a/changelogs/update-8419-translate-dates-in-new-sales-record-note
+++ b/changelogs/update-8419-translate-dates-in-new-sales-record-note
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Translate dates in NewSalesRecord note #8426

--- a/src-internal/Admin/Notes/NewSalesRecord.php
+++ b/src-internal/Admin/Notes/NewSalesRecord.php
@@ -94,9 +94,17 @@ class NewSalesRecord {
 			update_option( self::RECORD_DATE_OPTION_KEY, $yesterday );
 			update_option( self::RECORD_AMOUNT_OPTION_KEY, $total );
 
-			$formatted_yesterday   = gmdate( 'F jS', strtotime( $yesterday ) );
+			// Use F jS (March 7th) format for English speaking countries.
+			if ( substr( get_locale(), 0, 2 ) === 'en' ) {
+				$date_format = 'F jS';
+			} else {
+				// otherwise, fallback to the system date format.
+				$date_format = get_option( 'date_format' );
+			}
+
+			$formatted_yesterday   = date_i18n( $date_format, strtotime( $yesterday ) );
 			$formatted_total       = html_entity_decode( wp_strip_all_tags( wc_price( $total ) ) );
-			$formatted_record_date = gmdate( 'F jS', strtotime( $record_date ) );
+			$formatted_record_date = date_i18n( $date_format, strtotime( $record_date ) );
 			$formatted_record_amt  = html_entity_decode( wp_strip_all_tags( wc_price( $record_amt ) ) );
 
 			$content = sprintf(

--- a/src-internal/Admin/Notes/NewSalesRecord.php
+++ b/src-internal/Admin/Notes/NewSalesRecord.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Internal\Admin\Notes;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**

--- a/tests/notes/class-wc-tests-newsalesrecord-note.php
+++ b/tests/notes/class-wc-tests-newsalesrecord-note.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * NewSalesRecord note tests
+ *
+ * @package WooCommerce\Admin\Tests\Notes
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+
+/**
+ * Class WC_Tests_NewSalesRecord_Note
+ */
+class WC_Tests_NewSalesRecord_Note extends WC_Unit_Test_Case {
+
+	/**
+	 * @var string
+	 */
+	private $yesterday;
+
+	/**
+	 * Set up
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		NewSalesRecord::possibly_delete_note();
+
+		$this->yesterday = gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
+
+		$order = wc_create_order();
+		$order->set_total( 10 );
+		$order->set_date_created( $this->yesterday );
+		$order->update_status( 'Completed' );
+
+		update_option( NewSalesRecord::RECORD_DATE_OPTION_KEY, '2022-01-01' );
+		update_option( NewSalesRecord::RECORD_AMOUNT_OPTION_KEY, 1 );
+	}
+
+	/**
+	 * Test it uses f jS date format for English speaking countries.
+	 * @return void
+	 */
+	public function test_it_uses_fjS_date_format_for_english_speaking_countries() {
+		add_filter(
+			'locale',
+			function() {
+				return 'en_US';
+			}
+		);
+		NewSalesRecord::possibly_add_note();
+		$expected_date = date_i18n( 'F jS', strtotime( $this->yesterday ) );
+		$note          = Notes::get_note_by_name( NewSalesRecord::NOTE_NAME );
+		$this->assertTrue( strpos( $note->get_content(), "Woohoo, $expected_date" ) === 0 );
+	}
+
+	/**
+	 * Test it uses system date format for non-English speaking countries.
+	 * @return void
+	 */
+	public function test_it_uses_system_date_format_for_non_english_speaking_countries() {
+		add_filter(
+			'locale',
+			function() {
+				return 'es_MX';
+			}
+		);
+		NewSalesRecord::possibly_add_note();
+		$expected_date = date_i18n( get_option( 'date_format' ), strtotime( $this->yesterday ) );
+		$note          = Notes::get_note_by_name( NewSalesRecord::NOTE_NAME );
+		$this->assertTrue( strpos( $note->get_content(), $expected_date ) !== false );
+	}
+}

--- a/tests/notes/class-wc-tests-newsalesrecord-note.php
+++ b/tests/notes/class-wc-tests-newsalesrecord-note.php
@@ -5,8 +5,8 @@
  * @package WooCommerce\Admin\Tests\Notes
  */
 
-use Automattic\WooCommerce\Admin\Notes\NewSalesRecord;
 use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Internal\Admin\Notes\NewSalesRecord;
 
 /**
  * Class WC_Tests_NewSalesRecord_Note
@@ -24,8 +24,7 @@ class WC_Tests_NewSalesRecord_Note extends WC_Unit_Test_Case {
 	 */
 	public function setUp() {
 		parent::setUp();
-		NewSalesRecord::possibly_delete_note();
-
+		Notes::delete_notes_with_name( NewSalesRecord::NOTE_NAME );
 		$this->yesterday = gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
 
 		$order = wc_create_order();


### PR DESCRIPTION
Fixes #8419 

This PR uses [date_i18n](https://developer.wordpress.org/reference/functions/date_i18n/) to translate dates used in the note. 

This PR preserves the same date format (F jS) for English speaking countries but falls back to the system date format for non-English speaking countries.

### Detailed test instructions:

1. Open NewsSalesRecord.php note and add  `$total=100;` after this [line](https://github.com/woocommerce/woocommerce-admin/blob/main/src%2FNotes%2FNewSalesRecord.php#L72)
2. Run `wc_admin_daily` task
3. Confirm the note has been added and date format is in `F jS`
4. Navigate to `Settings -> General` and change the `Site Language` to Espanol
5. If necessary, go to `Dashboard -> Updates` and update the Translation files.
6. Delete `wc-admin-new-sales-record` from `wp_wc_admin_notes` table and increase value of `$total` from step 1.
7. Run `wc_admin_daily` task
8. Check the note and its date format.

