### PR TITLE
Add capability for ExPlat integration to authenticate WPCOM users

### DIFF
--- a/changelogs/add-8071-add-wpcom-authentication-for-explat
+++ b/changelogs/add-8071-add-wpcom-authentication-for-explat
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add capability for ExPlat integration to authenticate WPCOM users. #8428

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -18,6 +18,9 @@
 
 namespace WooCommerce\Admin;
 
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_client;
+
 /**
  * This class provides an interface to the Explat A/B tests.
  *
@@ -54,16 +57,25 @@ final class Experimental_Abtest {
 	private $consent = false;
 
 	/**
+	 * Request variation as a auth wpcom user or not.
+	 *
+	 * @var boolean
+	 */
+	private $as_auth_wpcom_user = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $anon_id ExPlat anonymous ID.
 	 * @param string $platform ExPlat platform name.
 	 * @param bool   $consent Whether tracking consent is given.
+	 * @param bool   $as_auth_wpcom_user  Request variation as a auth wp user or not.
 	 */
-	public function __construct( string $anon_id, string $platform, bool $consent ) {
-		$this->anon_id  = $anon_id;
-		$this->platform = $platform;
-		$this->consent  = $consent;
+	public function __construct( string $anon_id, string $platform, bool $consent, bool $as_auth_wpcom_user = false ) {
+		$this->anon_id            = $anon_id;
+		$this->platform           = $platform;
+		$this->consent            = $consent;
+		$this->as_auth_wpcom_user = $as_auth_wpcom_user;
 	}
 
 	/**
@@ -86,6 +98,38 @@ final class Experimental_Abtest {
 		}
 
 		return $variation;
+	}
+
+
+	/**
+	 * Perform the request for a experiment assignment of a provided A/B test from WP.com.
+	 *
+	 * @param array $args Arguments to pass to the request for A/B test.
+	 * @return array|\WP_Error A/B test variation error on failure.
+	 */
+	public function request_assignment( $args ) {
+		// Request as authenticated wp user.
+		if ( $this->as_auth_wpcom_user && class_exists( Jetpack_Connection_Manager::class ) ) {
+			$jetpack_connection_manager = new Jetpack_Connection_Manager();
+			if ( $jetpack_connection_manager->is_user_connected() ) {
+				$response = Jetpack_Connection_client::wpcom_json_api_request_as_user(
+					'/experiments/0.1.0/assignments/' . $this->platform,
+					'2',
+					$args
+				);
+			}
+		}
+
+		// Request as anonymous user.
+		if ( ! $this->as_auth_wpcom_user || ! isset( $response ) ) {
+			$response = wp_remote_get(
+				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/' .
+				$this->platform,
+				$args
+			);
+		}
+
+		return $response;
 	}
 
 	/**
@@ -120,7 +164,13 @@ final class Experimental_Abtest {
 		}
 
 		// Make the request to the WP.com API.
-		$response = $this->request_variation( $test_name );
+		$args     = array(
+			'experiment_name'  => $test_name,
+			'anon_id'          => rawurlencode( $this->anon_id ),
+			'woo_country_code' => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
+		);
+		$args     = apply_filters( 'woocommerce_explat_request_args', $args );
+		$response = $this->request_assignment( $args );
 
 		// Bail if there was an error or malformed response.
 		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
@@ -139,41 +189,12 @@ final class Experimental_Abtest {
 		$this->tests[ $test_name ] = $results['variations'][ $test_name ] ?? null;
 
 		$variation = $results['variations'][ $test_name ] ?? 'control';
-
 		// Store the variation in our external cache.
 		if ( ! empty( $results['ttl'] ) ) {
 			set_transient( 'abtest_variation_' . $test_name, $variation, $results['ttl'] );
 		}
 
 		return $variation;
-	}
-
-	/**
-	 * Perform the request for a variation of a provided A/B test from WP.com.
-	 *
-	 * @param string $test_name Name of the A/B test.
-	 * @return array|\WP_Error A/B test variation error on failure.
-	 */
-	protected function request_variation( $test_name ) {
-		$args = array(
-			'experiment_name'  => $test_name,
-			'anon_id'          => rawurlencode( $this->anon_id ),
-			'woo_country_code' => rawurlencode( get_option( 'woocommerce_default_country', 'US:CA' ) ),
-		);
-
-		$args = apply_filters( 'woocommerce_explat_request_args', $args );
-
-		$url = add_query_arg(
-			$args,
-			sprintf(
-				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/%s',
-				$this->platform
-			)
-		);
-
-		$get = wp_remote_get( $url );
-
-		return $get;
 	}
 }
 

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -121,7 +121,7 @@ final class Experimental_Abtest {
 		}
 
 		// Request as anonymous user.
-		if ( ! $this->as_auth_wpcom_user || ! isset( $response ) ) {
+		if ( ! isset( $response ) ) {
 			$response = wp_remote_get(
 				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/' .
 				$this->platform,

--- a/includes/class-experimental-abtest.php
+++ b/includes/class-experimental-abtest.php
@@ -122,11 +122,14 @@ final class Experimental_Abtest {
 
 		// Request as anonymous user.
 		if ( ! isset( $response ) ) {
-			$response = wp_remote_get(
-				'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/' .
-				$this->platform,
-				$args
+			$url      = add_query_arg(
+				$args,
+				sprintf(
+					'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/%s',
+					$this->platform
+				)
 			);
+			$response = wp_remote_get( $url );
 		}
 
 		return $response;

--- a/packages/explat/CHANGELOG.md
+++ b/packages/explat/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 -   Add missing dependencies. #8349
 -   Update all js packages with minor/patch version changes. #8392
+-   Add `@wordpress/api-fetch` as dependencies. #8428
+-   Export `*WithAuth` methods to authenticate WPCOM users. #8428
 # 2.0.0
 
 - Make ExPlat request URL args filterable. Added woocommerce_explat_request_args filter #8231

--- a/packages/explat/README.md
+++ b/packages/explat/README.md
@@ -29,4 +29,14 @@ const LoadingExperience = <div>⏰</div>;
 	treatmentExperience={ TreatmentExperience }
 	loadingExperience={ LoadingExperience }
 />;
+
+// Get the experiment assignment with authentication as a WPCOM user.
+import { ExperimentWithAuth } from '@woocommerce/explat';
+
+<ExperimentWithAuth
+	name="woocommerce_example_experiment"
+	defaultExperience={ DefaultExperience }
+	treatmentExperience={ TreatmentExperience }
+	loadingExperience={ LoadingExperience }
+/>;
 ```

--- a/packages/explat/package.json
+++ b/packages/explat/package.json
@@ -27,6 +27,7 @@
 	"dependencies": {
 		"@automattic/explat-client": "^0.0.3",
 		"@automattic/explat-client-react-helpers": "^0.0.3",
+		"@wordpress/api-fetch": "^6.0.1",
 		"@wordpress/hooks": "^2.12.3",
 		"cookie": "^0.4.2",
 		"qs": "^6.10.3"

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -69,7 +69,7 @@ export const fetchExperimentAssignment = async ( {
 	anonId: string | null;
 } ): Promise< unknown > =>
 	_fetchExperimentAssignment( {
-		url: `https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?`,
+		url: `https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce`,
 		experimentName,
 		anonId,
 	} );
@@ -82,6 +82,7 @@ export const fetchExperimentAssignmentWithAuth = async ( {
 	anonId: string | null;
 } ): Promise< unknown > =>
 	_fetchExperimentAssignment( {
+		// Send the request to our backend server to get the assignment with a user token via Jetpack.
 		path: '/wc-admin/experiments/assignment',
 		experimentName,
 		anonId,

--- a/packages/explat/src/assignment.ts
+++ b/packages/explat/src/assignment.ts
@@ -3,13 +3,18 @@
  */
 import { stringify } from 'qs';
 import { applyFilters } from '@wordpress/hooks';
+import apiFetch from '@wordpress/api-fetch';
 
 const EXPLAT_VERSION = '0.1.0';
 
-export const fetchExperimentAssignment = async ( {
+const _fetchExperimentAssignment = async ( {
+	url,
+	path,
 	experimentName,
 	anonId,
 }: {
+	url?: string;
+	path?: string;
 	experimentName: string;
 	anonId: string | null;
 } ): Promise< unknown > => {
@@ -17,6 +22,10 @@ export const fetchExperimentAssignment = async ( {
 		throw new Error(
 			`Tracking is disabled, can't fetch experimentAssignment`
 		);
+	}
+
+	if ( ! url && ! path ) {
+		throw new Error( 'Url or path is required' );
 	}
 
 	/**
@@ -33,21 +42,47 @@ export const fetchExperimentAssignment = async ( {
 	 * });
 	 *
 	 */
-	const params = applyFilters( 'woocommerce_explat_request_args', {
-		experiment_name: experimentName,
-		anon_id: anonId ?? undefined,
-		woo_country_code:
-			window.wcSettings?.preloadSettings?.general
-				?.woocommerce_default_country ||
-			window.wcSettings?.admin?.preloadSettings?.general
-				?.woocommerce_default_country,
-	} );
-
-	const response = await window.fetch(
-		`https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?${ stringify(
-			params
-		) }`
+	const queryString = stringify(
+		applyFilters( 'woocommerce_explat_request_args', {
+			experiment_name: experimentName,
+			anon_id: anonId ?? undefined,
+			woo_country_code:
+				window.wcSettings?.preloadSettings?.general
+					?.woocommerce_default_country ||
+				window.wcSettings?.admin?.preloadSettings?.general
+					?.woocommerce_default_country,
+		} )
 	);
 
-	return await response.json();
+	const response = await apiFetch( {
+		url: url && `${ url }?${ queryString }`,
+		path: path && `${ path }?${ queryString }`,
+	} );
+	return response;
 };
+
+export const fetchExperimentAssignment = async ( {
+	experimentName,
+	anonId,
+}: {
+	experimentName: string;
+	anonId: string | null;
+} ): Promise< unknown > =>
+	_fetchExperimentAssignment( {
+		url: `https://public-api.wordpress.com/wpcom/v2/experiments/${ EXPLAT_VERSION }/assignments/woocommerce?`,
+		experimentName,
+		anonId,
+	} );
+
+export const fetchExperimentAssignmentWithAuth = async ( {
+	experimentName,
+	anonId,
+}: {
+	experimentName: string;
+	anonId: string | null;
+} ): Promise< unknown > =>
+	_fetchExperimentAssignment( {
+		path: '/wc-admin/experiments/assignment',
+		experimentName,
+		anonId,
+	} );

--- a/packages/explat/src/index.ts
+++ b/packages/explat/src/index.ts
@@ -9,7 +9,10 @@ import createExPlatClientReactHelpers from '@automattic/explat-client-react-help
  */
 import { isDevelopmentMode } from './utils';
 import { logError } from './error';
-import { fetchExperimentAssignment } from './assignment';
+import {
+	fetchExperimentAssignment,
+	fetchExperimentAssignmentWithAuth,
+} from './assignment';
 import { getAnonId, initializeAnonId } from './anon';
 declare global {
 	interface Window {
@@ -38,9 +41,28 @@ export const {
 	loadExperimentAssignment,
 	dangerouslyGetExperimentAssignment,
 } = exPlatClient;
-const exPlatClientReactHelpers = createExPlatClientReactHelpers( exPlatClient );
+
 export const {
 	useExperiment,
 	Experiment,
 	ProvideExperimentData,
-} = exPlatClientReactHelpers;
+} = createExPlatClientReactHelpers( exPlatClient );
+
+// Create another auth client that send request to wpcom as auth user.
+const exPlatClientWithAuth = createExPlatClient( {
+	fetchExperimentAssignment: fetchExperimentAssignmentWithAuth,
+	getAnonId,
+	logError,
+	isDevelopmentMode,
+} );
+
+export const {
+	loadExperimentAssignment: loadExperimentAssignmentWithAuth,
+	dangerouslyGetExperimentAssignment: dangerouslyGetExperimentAssignmentWithAuth,
+} = exPlatClientWithAuth;
+
+export const {
+	useExperiment: useExperimentWithAuth,
+	Experiment: ExperimentWithAuth,
+	ProvideExperimentData: ProvideExperimentDataWithAuth,
+} = createExPlatClientReactHelpers( exPlatClientWithAuth );

--- a/packages/explat/src/test/assignment-test.js
+++ b/packages/explat/src/test/assignment-test.js
@@ -37,7 +37,7 @@ describe( 'fetchExperimentAssignment', () => {
 		Promise.resolve( fetchPromise );
 
 		expect( fetchMock ).toHaveBeenCalledWith(
-			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?%3Fanon_id=abc&test=test&_locale=user',
+			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test&_locale=user',
 			{
 				body: undefined,
 				credentials: 'include',

--- a/packages/explat/src/test/assignment-test.js
+++ b/packages/explat/src/test/assignment-test.js
@@ -37,12 +37,7 @@ describe( 'fetchExperimentAssignment', () => {
 		Promise.resolve( fetchPromise );
 
 		expect( fetchMock ).toHaveBeenCalledWith(
-			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test&_locale=user',
-			{
-				body: undefined,
-				credentials: 'include',
-				headers: { Accept: 'application/json, */*;q=0.1' },
-			}
+			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test'
 		);
 	} );
 } );

--- a/packages/explat/src/test/assignment-test.js
+++ b/packages/explat/src/test/assignment-test.js
@@ -6,7 +6,10 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { fetchExperimentAssignment } from '../assignment';
+import {
+	fetchExperimentAssignment,
+	fetchExperimentAssignmentWithAuth,
+} from '../assignment';
 global.fetch = jest
 	.fn()
 	.mockImplementation( () =>
@@ -34,7 +37,41 @@ describe( 'fetchExperimentAssignment', () => {
 		Promise.resolve( fetchPromise );
 
 		expect( fetchMock ).toHaveBeenCalledWith(
-			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?anon_id=abc&test=test'
+			'https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/woocommerce?%3Fanon_id=abc&test=test&_locale=user',
+			{
+				body: undefined,
+				credentials: 'include',
+				headers: { Accept: 'application/json, */*;q=0.1' },
+			}
+		);
+	} );
+} );
+
+describe( 'fetchExperimentAssignmentWithAuth', () => {
+	it( 'applies woocommerce_explat_request_args before constructing the full URL', () => {
+		fetchMock.mockClear();
+		addFilter(
+			'woocommerce_explat_request_args',
+			'test',
+			function ( args ) {
+				args.test = 'test';
+				return args;
+			}
+		);
+
+		const fetchPromise = fetchExperimentAssignmentWithAuth( {
+			experimentId: '123',
+			anonId: 'abc',
+		} );
+		Promise.resolve( fetchPromise );
+
+		expect( fetchMock ).toHaveBeenCalledWith(
+			'/wc-admin/experiments/assignment?anon_id=abc&test=test&_locale=user',
+			{
+				body: undefined,
+				credentials: 'include',
+				headers: { Accept: 'application/json, */*;q=0.1' },
+			}
 		);
 	} );
 } );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -879,6 +879,7 @@ importers:
       '@types/cookie': ^0.4.1
       '@types/node': ^17.0.21
       '@types/qs': ^6.9.7
+      '@wordpress/api-fetch': ^6.0.1
       '@wordpress/hooks': ^2.12.3
       cookie: ^0.4.2
       jest: ^27.5.1
@@ -890,6 +891,7 @@ importers:
     dependencies:
       '@automattic/explat-client': 0.0.3
       '@automattic/explat-client-react-helpers': 0.0.3
+      '@wordpress/api-fetch': 6.0.1
       '@wordpress/hooks': 2.12.3
       cookie: 0.4.2
       qs: 6.10.3

--- a/src/API/Experiments.php
+++ b/src/API/Experiments.php
@@ -60,7 +60,7 @@ class Experiments extends \WC_REST_Data_Controller {
 		$args = $request->get_query_params();
 
 		if ( ! isset( $args['experiment_name'] ) ) {
-			return new \WP_Error(
+			return new \WP_REST_Response(
 				'woocommerce_rest_experiment_name_required',
 				__( 'Sorry, experiment_name is required.', 'woocommerce-admin' ),
 				array( 'status' => 400 )
@@ -76,8 +76,8 @@ class Experiments extends \WC_REST_Data_Controller {
 			true  // set true to send request as auth user.
 		);
 		$response = $abtest->request_assignment( $args );
-		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
-			return new \WP_Error( 'failed_to_fetch_data', 'Unable to fetch the requested data.', array( 'status' => 503 ) );
+		if ( is_wp_error( $response ) ) {
+			return $response;
 		}
 
 		return json_decode( $response['body'], true );

--- a/src/API/Experiments.php
+++ b/src/API/Experiments.php
@@ -60,7 +60,7 @@ class Experiments extends \WC_REST_Data_Controller {
 		$args = $request->get_query_params();
 
 		if ( ! isset( $args['experiment_name'] ) ) {
-			return new \WP_REST_Response(
+			return new \WP_Error(
 				'woocommerce_rest_experiment_name_required',
 				__( 'Sorry, experiment_name is required.', 'woocommerce-admin' ),
 				array( 'status' => 400 )

--- a/src/API/Experiments.php
+++ b/src/API/Experiments.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * REST API Experiment Controller
+ *
+ * Handles requests to /experiment
+ */
+
+namespace Automattic\WooCommerce\Admin\API;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Data controller.
+ *
+ * @extends WC_REST_Data_Controller
+ */
+class Experiments extends \WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-admin';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'experiments';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/assignment',
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_assignment' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+
+	/**
+	 * Forward the experiment request to WP.com and return the WP.com response.
+	 *
+	 * @param \WP_REST_Request $request Request data.
+	 *
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function get_assignment( $request ) {
+		$args = $request->get_query_params();
+
+		if ( ! isset( $args['experiment_name'] ) ) {
+			return new \WP_Error(
+				'woocommerce_rest_experiment_name_required',
+				__( 'Sorry, experiment_name is required.', 'woocommerce-admin' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		unset( $args['rest_route'] );
+
+		$abtest   = new \WooCommerce\Admin\Experimental_Abtest(
+			$request->get_param( 'anon_id' ) ?? '',
+			'woocommerce',
+			true, // set consent to true here since frontend has checked it already.
+			true  // set true to send request as auth user.
+		);
+		$response = $abtest->request_assignment( $args );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return new \WP_Error( 'failed_to_fetch_data', 'Unable to fetch the requested data.', array( 'status' => 503 ) );
+		}
+
+		return json_decode( $response['body'], true );
+	}
+}

--- a/src/API/Init.php
+++ b/src/API/Init.php
@@ -59,6 +59,7 @@ class Init {
 			'Automattic\WooCommerce\Admin\API\Data',
 			'Automattic\WooCommerce\Admin\API\DataCountries',
 			'Automattic\WooCommerce\Admin\API\DataDownloadIPs',
+			'Automattic\WooCommerce\Admin\API\Experiments',
 			'Automattic\WooCommerce\Admin\API\Marketing',
 			'Automattic\WooCommerce\Admin\API\MarketingOverview',
 			'Automattic\WooCommerce\Admin\API\Options',

--- a/tests/api/experiments.php
+++ b/tests/api/experiments.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Options REST API Test
+ *
+ * @package WooCommerce\Admin\Tests\API
+ */
+
+use \Automattic\WooCommerce\Admin\API\Experiments;
+
+/**
+ * WC Tests API Options
+ */
+class WC_Tests_API_Experiments extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-admin/experiments';
+
+	/**
+	 * Setup test data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test getting assignment without valid permissions.
+	 */
+	public function test_get_assignment_without_permission() {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/assignment' );
+		$request->set_query_params( array( 'experiment_name' => 'test' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+
+	/**
+	 * Test getting assignment without valid params.
+	 */
+	public function test_get_assignment_without_experiment_name() {
+		wp_set_current_user( $this->user );
+
+		$request  = new WP_REST_Request( 'GET', $this->endpoint . '/assignment' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/includes/class-experimental-abtest-test.php
+++ b/tests/includes/class-experimental-abtest-test.php
@@ -13,7 +13,7 @@ use WooCommerce\Admin\Experimental_Abtest;
  *
  * @package WooCommerce\Admin
  */
-class Experimental_Abtest_Test extends WP_UnitTestCase {
+class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests woocommerce_explat_request_args filter is used to construct
@@ -23,8 +23,8 @@ class Experimental_Abtest_Test extends WP_UnitTestCase {
 		delete_transient( 'abtest_variation_control' );
 		add_filter(
 			'pre_http_request',
-			function( $arg1, $arg2, $url ) {
-				$this->assertTrue( false !== strpos( $url, 'test=test' ) );
+			function( $preempt, $parsed_args, $url ) {
+				$this->assertEquals( $parsed_args['test'], 'test' );
 				return array(
 					'response'    => 200,
 					'status_code' => 200,
@@ -48,5 +48,46 @@ class Experimental_Abtest_Test extends WP_UnitTestCase {
 
 		$exp = new Experimental_Abtest( 'anon', 'platform', true );
 		$exp->get_variation( 'control' );
+	}
+
+	/**
+	 * Tests retrieve the test variation when consent is false
+	 */
+	public function test_get_variation_return_control_when_no_consent() {
+		$exp = new Experimental_Abtest( 'anon', 'platform', false );
+		$this->assertEquals(
+			$exp->get_variation( 'test_experiment_name' ),
+			'control'
+		);
+	}
+
+		/**
+		 * Tests retrieve the test variation when consent is false
+		 */
+	public function test_get_variation() {
+		delete_transient( 'abtest_variation_control' );
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $parsed_args, $url ) {
+				return array(
+					'response'    => 200,
+					'status_code' => 200,
+					'success'     => 1,
+					'body'        => '{
+						"variations": {
+							"test_experiment_name": "treatment"
+						}
+					}',
+				);
+			},
+			10,
+			3
+		);
+
+		$exp = new Experimental_Abtest( 'anon', 'platform', true );
+		$this->assertEquals(
+			$exp->get_variation( 'test_experiment_name' ),
+			'treatment'
+		);
 	}
 }

--- a/tests/includes/class-experimental-abtest-test.php
+++ b/tests/includes/class-experimental-abtest-test.php
@@ -23,8 +23,8 @@ class Experimental_Abtest_Test extends WC_Unit_Test_Case {
 		delete_transient( 'abtest_variation_control' );
 		add_filter(
 			'pre_http_request',
-			function( $preempt, $parsed_args, $url ) {
-				$this->assertEquals( $parsed_args['test'], 'test' );
+			function( $arg1, $arg2, $url ) {
+				$this->assertTrue( false !== strpos( $url, 'test=test' ) );
 				return array(
 					'response'    => 200,
 					'status_code' => 200,


### PR DESCRIPTION
Fixes woocommerce/woocommerce-admin#8071

Enable php and js ExPlat code to send requests to wpcom as  a WPCOM user via Jetpack

- Updates the` Experimental_Abtest` class to support requesting ExPlat assignment as a WPCOM user
- Add experiments rest API for the frontend to get assignment as a WPCOM user
- Update `packages/explat` to export auth utils.

### Screenshots

![Screen Shot 2022-03-08 at 16 56 42](https://user-images.githubusercontent.com/4344253/157206251-afc6828c-538e-49bb-ab3b-1d492e0344c2.png)

### Detailed test instructions:

**Test php experiment code**

- Use a JN or ngrok proxy site
- Allow tacking in OBW
- Install and connect Jetpack
- Set up a sandbox (pdibGW-1v-p2)
- ssh to your sandbox
- enable global HTTP `sudo global-http enable`
- Change `ANON_ALLOWED` to `false` in`/home/wpcom/public_html/wp-content/rest-api-plugins/endpoints/experiments/class-assignments-controller.php` 
- Watch access log via `tail -f logs/access_log`
- Disable variations cache
- https://github.com/woocommerce/woocommerce-admin/blob/563930b1833387648bdc6eb6504be255b3411bac/includes/class-experimental-abtest.php#L156-L164
- Go to /wp-admin/admin.php?page=wc-admin
- You should see `403` Forbidden for experiments requests
```
GET /wpcom/v2/experiments/0.1.0/assignments/woocommerce HTTP/1.0" 403
```
- Set default `as_auth_wpcom_user` to `true`
- Reload the page
- You should see `200` now for experiments requests

```
"GET /wpcom/v2/experiments/0.1.0/assignments/woocommerce HTTP/1.0" 200  ---- -
```
 
**Test js experiment code**

- Import `useExperimentWithAuth` and replace the `useExperiment` with it in `client/tasks/tasks.tsx`.
- https://github.com/woocommerce/woocommerce-admin/blob/563930b1833387648bdc6eb6504be255b3411bac/client/tasks/tasks.tsx#L30
- Open the browser dev tool and go to network tab
- Go to /wp-admin/admin.php?page=wc-admin
- Search 'woocommerce_tasklist_progression&' 
- You should see it send a request to your backend server with the 200 status response.



<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->