### PR TITLE
Fixing home item appearing in extensions menu on Woo Navigation

### DIFF
--- a/src/Features/Navigation/CoreMenu.php
+++ b/src/Features/Navigation/CoreMenu.php
@@ -189,7 +189,7 @@ class CoreMenu {
 		}
 
 		$home_item = array();
-		if ( defined( '\Automattic\WooCommerce\Internal\Admin\Features\Homescreen::MENU_SLUG' ) ) {
+		if ( defined( '\Automattic\WooCommerce\Internal\Admin\Homescreen::MENU_SLUG' ) ) {
 			$home_item = array(
 				'id'              => 'woocommerce-home',
 				'title'           => __( 'Home', 'woocommerce-admin' ),


### PR DESCRIPTION
Fixes #8430

In some of the work in making classes internal, an issue emerged with the Woo Navigation in which the _Home_ item was appearing under the "Extensions" menu. Ended up being a typo in a class check.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/157328824-944c3f10-a18b-45c0-990b-0d233821f2ff.png)


### Detailed test instructions:

-   Checkout branch
-   Enable new navigation in `Woocommerce -> Settings -> Advanced -> Features -> Checkbox`
- Observe that the _Home_ menu item appears at the top of the primary menu.
