### PR TITLE
Display WCPay task when installed via subscriptions option on profiler

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Display WCPay task when installed via subscriptions option on profiler
+
+1. Start with a fresh install.
+2. Navigate to WooCommerce -> Home to start the OBW.
+3. Ensure you select "subscriptions" under the step for product types.
+4. Complete the rest of the onboarding wizard.
+5. Confirm that "Get paid with WooCommerce Payments" appears under primary task list.
+6. When clicked, it should redirect to WCPay connection page.
+6. Confirm that "Set up additional payment providers" appears under extended task list.
+7. When clicked, it should direct to the payments task.
+
 ## 3.3.0
 
 ### Prompt a modal to save any unsaved changes in OBW

--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -10,8 +10,9 @@
 4. Complete the rest of the onboarding wizard.
 5. Confirm that "Get paid with WooCommerce Payments" appears under primary task list.
 6. When clicked, it should redirect to WCPay connection page.
-6. Confirm that "Set up additional payment providers" appears under extended task list.
-7. When clicked, it should direct to the payments task.
+7. Set up/connect WooCommerce Payments.
+8. After WCPay is connected, go to the Homescreen and confirm that "Set up additional payment providers" appears under extended task list.
+9. When clicked, it should direct to the payments task.
 
 ## 3.3.0
 

--- a/changelogs/update-8240
+++ b/changelogs/update-8240
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Update
+
+Display WCPay task when installed via subscriptions option on profiler

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -107,8 +107,9 @@ class WooCommercePayments extends Task {
 	 */
 	public static function is_requested() {
 		$profiler_data       = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
+		$product_types       = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 		$business_extensions = isset( $profiler_data['business_extensions'] ) ? $profiler_data['business_extensions'] : array();
-		return in_array( 'woocommerce-payments', $business_extensions, true );
+		return in_array( 'woocommerce-payments', $business_extensions, true ) || in_array( 'subscriptions', $product_types, true );
 	}
 
 	/**

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -109,7 +109,9 @@ class WooCommercePayments extends Task {
 		$profiler_data       = get_option( Onboarding::PROFILE_DATA_OPTION, array() );
 		$product_types       = isset( $profiler_data['product_types'] ) ? $profiler_data['product_types'] : array();
 		$business_extensions = isset( $profiler_data['business_extensions'] ) ? $profiler_data['business_extensions'] : array();
-		return in_array( 'woocommerce-payments', $business_extensions, true ) || in_array( 'subscriptions', $product_types, true );
+
+		$subscriptions_and_us = in_array( 'subscriptions', $product_types, true ) && 'US' === WC()->countries->get_base_country();
+		return in_array( 'woocommerce-payments', $business_extensions, true ) || $subscriptions_and_us;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8240

Modifying logic for WCPay task so that it is displayed when installed via the subscriptions option in the profiler. More details in the linked issue.

### Screenshots

![image](https://user-images.githubusercontent.com/444632/157502580-3711ed2b-85bf-42c6-82b3-243fdb7b299e.png)

### Detailed test instructions:

-   Checkout branch on fresh store
-   Proceed through onboarding wizard, selection "subscriptions" on the product types step.
- When complete, confirm that "Get paid with WooCommerce Payments" appears under primary tasks list.
- When clicked, it should direct to WCPay Connect page.
- Confirm that "Set up additional payment providers" appears under extended tasks list.
- When clicked, it should direct to Payments task.
