### PR TITLE
Fix error possibly_update_note call to get_content() on null

### DIFF
--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -150,17 +150,25 @@ trait NoteTraits {
 	 * @throws NotesUnavailableException Throws exception when notes are unavailable.
 	 */
 	public static function possibly_update_note() {
-		$note = Notes::get_note_by_name( self::NOTE_NAME );
+		$note_in_db = Notes::get_note_by_name( self::NOTE_NAME );
+		if ( ! $note_in_db ) {
+			return;
+		}
 
-		if ( ! $note ) {
+		if ( ! method_exists( self::class, 'get_note' ) ) {
+			return;
+		}
+
+		$note = self::get_note();
+		if ( ! $note instanceof Note && ! $note instanceof WC_Admin_Note ) {
 			return;
 		}
 
 		// Update note content if it's changed.
-		$latest_note_content = self::get_note()->get_content();
-		if ( $note->get_content() !== $latest_note_content ) {
-			$note->set_content( $latest_note_content );
-			$note->save();
+		$latest_note_content = $note->get_content();
+		if ( $note_in_db->get_content() !== $latest_note_content ) {
+			$note_in_db->set_content( $latest_note_content );
+			$note_in_db->save();
 		}
 	}
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/issues/8444

This PR fixes a bug from https://github.com/woocommerce/woocommerce-admin/pull/8401 that some notes might return `null` in `get_note()` when note should not be added. 

I also found that some notes actually don't have the `get_note` method. I'll create an issue to refactor the notes to ensure all notes have `get_note` method.

### Screenshots

```
[10-Mar-2022 00:25:30 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get_content() on null in /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-content/plugins/woocommerce-admin/src/Notes/NoteTraits.php:160
Stack trace:
#0 /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-content/plugins/woocommerce-admin/src-internal/Admin/Events.php(162): Automattic\WooCommerce\Internal\Admin\Notes\MobileApp::possibly_update_note()
#1 /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-content/plugins/woocommerce-admin/src-internal/Admin/Events.php(95): Automattic\WooCommerce\Internal\Admin\Events->possibly_update_notes()
#2 /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-includes/class-wp-hook.php(307): Automattic\WooCommerce\Internal\Admin\Events->do_wc_admin_daily('')
#3 /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters('', Array)
#4 /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-includes/plugin.php(474): WP_Hook->do_action(Array) in /Users/moonkuykyong/Dev/woocommerce-dev-docker/wordpress/wp-content/plugins/woocommerce-admin/src/Notes/NoteTraits.php on line 160
```

### Detailed test instructions:

1. Use a new site
2. Install wp-crontrol
3. Complete OBW
4. Go to WooCommerce > Home
5. Confirm `You now have access to the WooCommerce navigation` note is in the Inbox.
6. Change [this line](https://github.com/woocommerce/woocommerce-admin/blob/d603556f11d4acfbf5405fa3386c60556f9351e1/src-internal/Admin/Notes/NavigationNudge.php#L52) to return false.
7. Go to **Tool > Cron Events**
8. Run `wc_admin_daily`
9. There should no PHP Fatal error in the in debug.log file

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->

no changelog