### PR TITLE
Fix failing `test_cancel_import`  and `WC_Tests_API_Reports_Variations` php tests

### DIFF
--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -200,7 +200,12 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Verify there are actions to cancel.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$pending_hooks   = array_map( fn( $action) => $action->get_hook(), $pending_actions );
+		$pending_hooks   = array_map(
+			function ( $action ) {
+				return $action->get_hook();
+			},
+			$pending_actions
+		);
 		$this->assertContains( 'wc-admin_import_orders', $pending_hooks );
 		$this->assertContains( 'wc-admin_import_customers', $pending_hooks );
 
@@ -214,7 +219,12 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Verify there are no pending actions.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$pending_hooks   = array_map( fn( $action) => $action->get_hook(), $pending_actions );
+		$pending_hooks   = array_map(
+			function ( $action ) {
+				return $action->get_hook();
+			},
+			$pending_actions
+		);
 		$this->assertNotContains( 'wc-admin_import_orders', $pending_hooks );
 		$this->assertNotContains( 'wc-admin_import_customers', $pending_hooks );
 	}

--- a/tests/api/reports-import.php
+++ b/tests/api/reports-import.php
@@ -200,7 +200,9 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Verify there are actions to cancel.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$this->assertCount( 2, $pending_actions ); // 1 for the user, 1 for order.
+		$pending_hooks   = array_map( fn( $action) => $action->get_hook(), $pending_actions );
+		$this->assertContains( 'wc-admin_import_orders', $pending_hooks );
+		$this->assertContains( 'wc-admin_import_customers', $pending_hooks );
 
 		// Cancel outstanding actions.
 		$request  = new WP_REST_Request( 'POST', $this->endpoint . '/cancel' );
@@ -212,7 +214,9 @@ class WC_Tests_API_Reports_Import extends WC_REST_Unit_Test_Case {
 
 		// Verify there are no pending actions.
 		$pending_actions = WC_Helper_Queue::get_all_pending();
-		$this->assertCount( 0, $pending_actions );
+		$pending_hooks   = array_map( fn( $action) => $action->get_hook(), $pending_actions );
+		$this->assertNotContains( 'wc-admin_import_orders', $pending_hooks );
+		$this->assertNotContains( 'wc-admin_import_customers', $pending_hooks );
 	}
 
 	/**

--- a/tests/api/reports-variations.php
+++ b/tests/api/reports-variations.php
@@ -25,6 +25,9 @@ class WC_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 	 */
 	public function setUp() {
 		parent::setUp();
+		$this->product = new WC_Product_Variable();
+		$this->product->set_name( 'Variable Product' );
+		$this->product->save();
 
 		$this->user = $this->factory->user->create(
 			array(
@@ -55,6 +58,7 @@ class WC_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 
 		// Populate all of the data.
 		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $this->product->get_id() );
 		$variation->set_name( 'Test Variation' );
 		$variation->set_regular_price( 25 );
 		$variation->set_attributes( array( 'color' => 'green' ) );
@@ -95,12 +99,14 @@ class WC_Tests_API_Reports_Variations extends WC_REST_Unit_Test_Case {
 
 		// Populate all of the data.
 		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $this->product->get_id() );
 		$variation->set_name( 'Test Variation' );
 		$variation->set_regular_price( 25 );
 		$variation->set_attributes( array( 'color' => 'green' ) );
 		$variation->save();
 
 		$variation_2 = new WC_Product_Variation();
+		$variation_2->set_parent_id( $this->product->get_id() );
 		$variation_2->set_name( 'Test Variation 2' );
 		$variation_2->set_regular_price( 100 );
 		$variation_2->set_attributes( array( 'color' => 'red' ) );


### PR DESCRIPTION
Fixes #8439

This PR fixes the failing PHP tests.

I've confirmed the following issues are due to `woocommerce 6.3.0` by [rollbacking the WC version to `6.2.1`](https://github.com/woocommerce/woocommerce-admin/runs/5490684978?check_suite_focus=true). 

1.  Fixes the `test_cancel_import` test that size doesn't match expected by updating the `test_cancel_import` test case to explicitly assert the actions instead of asserting count.

There is an `action_scheduler/migration_hook` hook in the job queue in 6.3.0.

```
1) WC_Tests_API_Reports_Import::test_cancel_import
Failed asserting that actual size 3 matches expected size 2.

/tmp/wordpress/wp-content/plugins/woocommerce-admin/tests/api/reports-import.php:203
```

2.  Fixes the `WC_Tests_API_Reports_Variations` tests by assigning `parent_id` to product variations. Looks like 6.3.0 doesn't allow to create a product variation without assigning it to a product.

```
TypeError: Argument 1 passed to Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore::get_attribute_taxonomies() must be an instance of WC_Product, boolean given, called in /tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php on line 444

/tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php:582
/tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php:444
/tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php:3[49](https://github.com/woocommerce/woocommerce-admin/runs/5490996906?check_suite_focus=true#step:9:49)
/tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php:227
/tmp/wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php:[51](https://github.com/woocommerce/woocommerce-admin/runs/5490996906?check_suite_focus=true#step:9:51)
/tmp/wordpress/wp-includes/class-wp-hook.php:287
/tmp/wordpress/wp-includes/class-wp-hook.php:311
/tmp/wordpress/wp-includes/plugin.php:[55](https://github.com/woocommerce/woocommerce-admin/runs/5490996906?check_suite_focus=true#step:9:55)1
/tmp/wordpress/wp-content/plugins/woocommerce/packages/action-scheduler/classes/actions/ActionScheduler_Action.php:22
/tmp/wordpress/wp-content/plugins/woocommerce/packages/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php:65
/tmp/wordpress/wp-content/plugins/woocommerce-admin/tests/framework/helpers/class-wc-helper-queue.php:41
/tmp/wordpress/wp-content/plugins/woocommerce-admin/tests/api/reports-variations.php:68
```


I think the tests failed because of the changes from [this PR](https://github.com/woocommerce/woocommerce/pull/31256).


no changelog