### PR TITLE
Add `moment-timezone` to `@woocommerce/components` package.json

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Replace deprecated wp.compose.withState with wp.element.useState. #8338
 -   Add missing dependencies. #8349
 -   Update all js packages with minor/patch version changes. #8392
+-   Add moment-timezone to package.json. #6483
 
 # 9.0.0
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,6 +61,7 @@
 		"gridicons": "^3.4.0",
 		"memoize-one": "^5.2.1",
 		"moment": "^2.29.1",
+		"moment-timezone": "^0.5.34",
 		"prop-types": "^15.8.1",
 		"react-dates": "^17.2.0",
 		"react-router-dom": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,7 @@ importers:
       gridicons: ^3.4.0
       memoize-one: ^5.2.1
       moment: ^2.29.1
+      moment-timezone: ^0.5.34
       prop-types: ^15.8.1
       react-dates: ^17.2.0
       react-router-dom: ^5.3.0
@@ -489,6 +490,7 @@ importers:
       gridicons: 3.4.0_react@17.0.2
       memoize-one: 5.2.1
       moment: 2.29.1
+      moment-timezone: 0.5.34
       prop-types: 15.8.1
       react-dates: 17.2.0_d0804d3726ad84366bcc42e494508e1e
       react-router-dom: 5.3.0_react@17.0.2


### PR DESCRIPTION
Fixes #6483

This PR fixes that`@woocommerce/components` dependency breaks tests by adding the required `moment-timezone` to  package.json.

We don't explicitly require it in our code but we need it to use `moment().tz()`.

### Detailed test instructions:

**Reproduce the `TypeError: Cannot read property 'add' of undefined` error**

```bash
git clone https://github.com/tomalec/wc-components-tests.git
cd wc-components-tests
```

Update dependencies in `package.json` to the latest:

```json
	"dependencies": {
		"@woocommerce/components": "^9.0.0",
		"@woocommerce/date": "^4.0.0",
		"@woocommerce/navigation": "^7.0.0",
		"@wordpress/date": "^4.3.1"
	}
```


```bash
npm install
npm run test-unit

 FAIL  js/src/test/fails.js
  ● Test suite failed to run

    TypeError: Cannot read property 'add' of undefined

      1 | // Any of this breaks
    > 2 | import foo from "@woocommerce/components";
        | ^
      3 |
      4 | describe("Dependencies", () => {
      5 |   test("should not break tests", () => {

      at setupWPTimezone (node_modules/@woocommerce/components/node_modules/@wordpress/date/build/@wordpress/date/src/index.js:189:15)
      at Object.<anonymous> (node_modules/@woocommerce/components/node_modules/@wordpress/date/build/@wordpress/date/src/index.js:579:1)
      at Object.<anonymous> (node_modules/@woocommerce/components/build/date/index.js:10:16)
      at Object.<anonymous> (node_modules/@woocommerce/components/build/index.js:21:14)
      at Object.<anonymous> (js/src/test/fails.js:2:1)
```

**Should pass tests after adding `moment-timezone`**

```bash
cd node_modules/@woocommerce/components
npm install moment-timezone
cd ../../../
npm run test-unit

 PASS  js/src/test/fails.js
  Dependencies
    ✓ should not break tests
```


no changelog