### PR TITLE
Refactor the `onFilterChange` method in the `AdvancedFilters` component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 -   Add missing dependencies. #8349
 -   Update all js packages with minor/patch version changes. #8392
 -   Add moment-timezone to package.json. #6483
+-   Refactor the `onFilterChange` method in the `AdvancedFilters` component. #8459
 
 # 9.0.0
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,8 +4,10 @@
 -   Add missing dependencies. #8349
 -   Update all js packages with minor/patch version changes. #8392
 -   Add moment-timezone to package.json. #6483
--   Refactor the `onFilterChange` method in the `AdvancedFilters` component. #8459
+## Breaking changes
 
+-   Refactor the `onFilterChange` method in the `AdvancedFilters` component. #8459
+    - change: `onFilterChange( index, property, value, shouldResetValue = false );` to `onFilterChange( index, { property, value, shouldResetValue = false } )`;
 # 9.0.0
 
 -   Update line-height of SelectControl label to avoid truncated descenders in some typefaces and zoom levels. #8186

--- a/packages/components/src/advanced-filters/attribute-filter.js
+++ b/packages/components/src/advanced-filters/attribute-filter.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import { SelectControl as Select, Spinner } from '@wordpress/components';
-import { partial } from 'lodash';
 import interpolateComponents from '@automattic/interpolate-components';
 import classnames from 'classnames';
 import {
@@ -167,7 +166,12 @@ const AttributeFilter = ( props ) => {
 								) }
 								options={ rules }
 								value={ rule }
-								onChange={ partial( onFilterChange, 'rule' ) }
+								onChange={ ( selectedValue ) =>
+									onFilterChange( {
+										property: 'rule',
+										value: selectedValue,
+									} )
+								}
 								aria-label={ labels.rule }
 							/>
 						),
@@ -188,12 +192,12 @@ const AttributeFilter = ( props ) => {
 												attr ? [ attr ] : []
 											);
 											setSelectedAttributeTerm( '' );
-											onFilterChange(
-												'value',
-												[ attr && attr.key ].filter(
-													Boolean
-												)
-											);
+											onFilterChange( {
+												property: 'value',
+												value: [
+													attr && attr.key,
+												].filter( Boolean ),
+											} );
 										} }
 										type="attributes"
 										placeholder={ __(
@@ -241,14 +245,14 @@ const AttributeFilter = ( props ) => {
 													setSelectedAttributeTerm(
 														term
 													);
-													onFilterChange(
-														'value',
-														[
+													onFilterChange( {
+														property: 'value',
+														value: [
 															selectedAttribute[ 0 ]
 																.key,
 															term,
-														].filter( Boolean )
-													);
+														].filter( Boolean ),
+													} );
 												} }
 											/>
 										</Fragment>

--- a/packages/components/src/advanced-filters/date-filter.js
+++ b/packages/components/src/advanced-filters/date-filter.js
@@ -100,7 +100,10 @@ class DateFilter extends Component {
 		this.setState( { before: date, beforeText: text, beforeError: error } );
 
 		if ( date ) {
-			onFilterChange( 'value', date.format( isoDateFormat ) );
+			onFilterChange( {
+				property: 'value',
+				value: date.format( isoDateFormat ),
+			} );
 		}
 	}
 
@@ -129,7 +132,10 @@ class DateFilter extends Component {
 			}
 
 			if ( nextAfter && nextBefore ) {
-				onFilterChange( 'value', [ nextAfter, nextBefore ] );
+				onFilterChange( {
+					property: 'value',
+					value: [ nextAfter, nextBefore ],
+				} );
 			}
 		}
 	}
@@ -159,7 +165,11 @@ class DateFilter extends Component {
 			...newDateState,
 		} );
 
-		onFilterChange( 'rule', newRule, shouldResetValue );
+		onFilterChange( {
+			property: 'rule',
+			value: newRule,
+			shouldResetValue,
+		} );
 	}
 
 	isFutureDate( dateString ) {

--- a/packages/components/src/advanced-filters/index.js
+++ b/packages/components/src/advanced-filters/index.js
@@ -117,7 +117,7 @@ class AdvancedFilters extends Component {
 		onAdvancedFilterAction( 'match', { match } );
 	}
 
-	onFilterChange( index, property, value, shouldResetValue = false ) {
+	onFilterChange( index, { property, value, shouldResetValue = false } ) {
 		const newActiveFilters = [ ...this.state.activeFilters ];
 		newActiveFilters[ index ] = {
 			...newActiveFilters[ index ],

--- a/packages/components/src/advanced-filters/number-filter.js
+++ b/packages/components/src/advanced-filters/number-filter.js
@@ -3,7 +3,7 @@
  */
 import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl, TextControl } from '@wordpress/components';
-import { get, find, partial, isArray } from 'lodash';
+import { get, find, isArray } from 'lodash';
 import interpolateComponents from '@automattic/interpolate-components';
 import classnames from 'classnames';
 import { sprintf, __, _x } from '@wordpress/i18n';
@@ -137,7 +137,10 @@ class NumberFilter extends Component {
 		if ( Boolean( rangeEnd ) ) {
 			// If there's a value for rangeEnd, we've just changed from "between"
 			// to "less than" or "more than" and need to transition the value
-			onFilterChange( 'value', rangeStart || rangeEnd );
+			onFilterChange( {
+				property: 'value',
+				value: rangeStart || rangeEnd,
+			} );
 		}
 
 		let labelFormat = '';
@@ -166,7 +169,8 @@ class NumberFilter extends Component {
 			label: sprintf( labelFormat, {
 				field: get( config, [ 'labels', 'add' ] ),
 			} ),
-			onChange: partial( onFilterChange, 'value' ),
+			onChange: ( value ) =>
+				onFilterChange( { property: 'value', value } ),
 			currencySymbol,
 			symbolPosition,
 		} );
@@ -181,11 +185,17 @@ class NumberFilter extends Component {
 			: [ filter.value ];
 
 		const rangeStartOnChange = ( newRangeStart ) => {
-			onFilterChange( 'value', [ newRangeStart, rangeEnd ] );
+			onFilterChange( {
+				property: 'value',
+				key: [ newRangeStart, rangeEnd ],
+			} );
 		};
 
 		const rangeEndOnChange = ( newRangeEnd ) => {
-			onFilterChange( 'value', [ rangeStart, newRangeEnd ] );
+			onFilterChange( {
+				property: 'value',
+				key: [ rangeStart, newRangeEnd ],
+			} );
 		};
 
 		return interpolateComponents( {
@@ -245,7 +255,9 @@ class NumberFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, 'rule' ) }
+						onChange={ ( value ) =>
+							onFilterChange( { property: 'rule', value } )
+						}
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/search-filter.js
+++ b/packages/components/src/advanced-filters/search-filter.js
@@ -4,7 +4,7 @@
 import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 import { getIdsFromQuery } from '@woocommerce/navigation';
-import { find, isEqual, partial } from 'lodash';
+import { find, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from '@automattic/interpolate-components';
 import classnames from 'classnames';
@@ -72,7 +72,7 @@ class SearchFilter extends Component {
 		} );
 		const { onFilterChange } = this.props;
 		const idList = values.map( ( value ) => value.key ).join( ',' );
-		onFilterChange( 'value', idList );
+		onFilterChange( { property: 'value', value: idList } );
 	}
 
 	getScreenReaderText( filter, config ) {
@@ -120,7 +120,9 @@ class SearchFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, 'rule' ) }
+						onChange={ ( value ) =>
+							onFilterChange( { property: 'rule', value } )
+						}
 						aria-label={ labels.rule }
 					/>
 				),

--- a/packages/components/src/advanced-filters/select-filter.js
+++ b/packages/components/src/advanced-filters/select-filter.js
@@ -3,7 +3,7 @@
  */
 import { createElement, Component, Fragment } from '@wordpress/element';
 import { SelectControl, Spinner } from '@wordpress/components';
-import { find, partial } from 'lodash';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import interpolateComponents from '@automattic/interpolate-components';
 import classnames from 'classnames';
@@ -33,7 +33,7 @@ class SelectFilter extends Component {
 							config,
 							returnedOptions
 						);
-						onFilterChange( 'value', value );
+						onFilterChange( { property: 'value', value } );
 					}
 				} );
 		}
@@ -88,7 +88,12 @@ class SelectFilter extends Component {
 						) }
 						options={ rules }
 						value={ rule }
-						onChange={ partial( onFilterChange, 'rule' ) }
+						onChange={ ( selectedValue ) =>
+							onFilterChange( {
+								property: 'rule',
+								value: selectedValue,
+							} )
+						}
 						aria-label={ labels.rule }
 					/>
 				),
@@ -100,7 +105,12 @@ class SelectFilter extends Component {
 						) }
 						options={ options }
 						value={ value }
-						onChange={ partial( onFilterChange, 'value' ) }
+						onChange={ ( selectedValue ) =>
+							onFilterChange( {
+								property: 'value',
+								value: selectedValue,
+							} )
+						}
 						aria-label={ labels.filter }
 					/>
 				) : (

--- a/packages/components/src/advanced-filters/stories/index.js
+++ b/packages/components/src/advanced-filters/stories/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { AdvancedFilters } from '@woocommerce/components';
-import { getSetting } from '@woocommerce/settings';
 
 const ORDER_STATUSES = {
 	cancelled: 'Cancelled',
@@ -15,7 +14,15 @@ const ORDER_STATUSES = {
 };
 
 const siteLocale = 'en_US';
-const currency = getSetting( 'currency' );
+const currency = {
+	code: 'USD',
+	decimalSeparator: '.',
+	precision: 2,
+	priceFormat: '%1$s%2$s',
+	symbol: '$',
+	symbolPosition: 'left',
+	thousandSeparator: ',',
+};
 const path = new URL( document.location ).searchParams.get( 'path' );
 const query = {
 	component: 'advanced-filters',


### PR DESCRIPTION
Fixes #7470

Refactored the `onFilterChange` method to remove the multiple arguments and instead accept `index` param and an object param.

Also, fixed the `undefined` currency error in the storybook.


### Screenshots
![Screen Shot 2022-03-11 at 15 21 15](https://user-images.githubusercontent.com/4344253/157821026-90be7242-8326-474c-adcf-7c8e83e75846.png)


### Detailed test instructions:

- Place some orders
- Go to **Analytics > Orders**
- Click **Show > Advanced filters**
- Verify filters still work

Verify the storybook fix

- Run `npm run storybook`
- Visit http://localhost:6007/ in your browser
- Navigate to the `AdvancedFilters` story from the left-hand side panel
- Add a filter and choose `Subtotal`
- Storybook should not throw the undefined error below

![Screen Shot 2022-03-11 at 15 27 26](https://user-images.githubusercontent.com/4344253/157822019-b5468d6a-3c3b-410a-a9f1-739103770817.png)


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->

no changelog