### PR TITLE
Experimental: Add filters to allow simple products to be included in Variations analytics report

### DIFF
--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -209,7 +209,7 @@ class VariationsReportTable extends Component {
 				/**
 				 * Experimental: Filter the label used for the number of variations in the report table summary.
 				 *
-				 * @filter EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER
+				 * @filter experimental_woocommerce_admin_variations_report_table_summary_variations_count_label
 				 *
 				 * @param {string} label Label used for the count.
 				 * @param {string} variationsCount Number of variations.

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -19,10 +19,10 @@ import { CurrencyContext } from '../../../lib/currency-context';
 import { getVariationName } from '../../../lib/async-requests';
 import { getAdminSetting } from '~/utils/admin-settings';
 
-const INTERNAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER =
-	'internal_woocommerce_admin_variations_report_table_title';
-const INTERNAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER =
-	'internal_woocommerce_admin_variations_report_table_summary_variations_count_label';
+const EXPERIMENTAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER =
+	'experimental_woocommerce_admin_variations_report_table_title';
+const EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER =
+	'experimental_woocommerce_admin_variations_report_table_summary_variations_count_label';
 
 const manageStock = getAdminSetting( 'manageStock', 'no' );
 const stockStatuses = getAdminSetting( 'stockStatuses', {} );
@@ -207,7 +207,7 @@ class VariationsReportTable extends Component {
 		return [
 			{
 				label: applyFilters(
-					INTERNAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER,
+					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER,
 					_n(
 						'variation sold',
 						'variations sold',
@@ -291,7 +291,7 @@ class VariationsReportTable extends Component {
 					variations: query.variations,
 				} }
 				title={ applyFilters(
-					INTERNAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,
+					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,
 					__( 'Variations', 'woocommerce-admin' ),
 					query
 				) }

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -206,6 +206,15 @@ class VariationsReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
+				/**
+				 * Experimental: Filter the label used for the number of variations in the report table summary.
+				 *
+				 * @filter EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER
+				 *
+				 * @param {string} label Label used for the count.
+				 * @param {string} variationsCount Number of variations.
+				 * @param {Array} query Query parameters.
+				 */
 				label: applyFilters(
 					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER,
 					_n(
@@ -290,6 +299,14 @@ class VariationsReportTable extends Component {
 					product_includes: query.product_includes,
 					variations: query.variations,
 				} }
+				/**
+				 * Experimental: Filter the title used for the report table.
+				 *
+				 * @filter experimental_woocommerce_admin_variations_report_table_title
+				 *
+				 * @param {string} title Title used for the report table.
+				 * @param {Array} query Query parameters.
+				 */
 				title={ applyFilters(
 					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,
 					__( 'Variations', 'woocommerce-admin' ),

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __, _n, _x } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import { Component } from '@wordpress/element';
 import { map } from 'lodash';
 import { Link } from '@woocommerce/components';
@@ -17,6 +18,11 @@ import { isLowStock } from '../products/utils';
 import { CurrencyContext } from '../../../lib/currency-context';
 import { getVariationName } from '../../../lib/async-requests';
 import { getAdminSetting } from '~/utils/admin-settings';
+
+const INTERNAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER =
+	'internal_woocommerce_admin_variations_report_table_title';
+const INTERNAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER =
+	'internal_woocommerce_admin_variations_report_table_summary_variations_count_label';
 
 const manageStock = getAdminSetting( 'manageStock', 'no' );
 const stockStatuses = getAdminSetting( 'stockStatuses', {} );
@@ -189,6 +195,7 @@ class VariationsReportTable extends Component {
 	}
 
 	getSummary( totals ) {
+		const { query } = this.props;
 		const {
 			variations_count: variationsCount = 0,
 			items_sold: itemsSold = 0,
@@ -199,11 +206,16 @@ class VariationsReportTable extends Component {
 		const currency = getCurrencyConfig();
 		return [
 			{
-				label: _n(
-					'variation sold',
-					'variations sold',
+				label: applyFilters(
+					INTERNAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER,
+					_n(
+						'variation sold',
+						'variations sold',
+						variationsCount,
+						'woocommerce-admin'
+					),
 					variationsCount,
-					'woocommerce-admin'
+					query
 				),
 				value: formatValue( currency, 'number', variationsCount ),
 			},
@@ -278,7 +290,11 @@ class VariationsReportTable extends Component {
 					product_includes: query.product_includes,
 					variations: query.variations,
 				} }
-				title={ __( 'Variations', 'woocommerce-admin' ) }
+				title={ applyFilters(
+					INTERNAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,
+					__( 'Variations', 'woocommerce-admin' ),
+					query
+				) }
 				columnPrefsKey="variations_report_columns"
 				filters={ filters }
 				advancedFilters={ advancedFilters }

--- a/src/API/Reports/Variations/Controller.php
+++ b/src/API/Reports/Variations/Controller.php
@@ -55,7 +55,14 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$args              = array();
+		$args = array();
+		/**
+		 * Experimental: Filter the list of parameters provided when querying data from the data store.
+		 *
+		 * @ignore
+		 *
+		 * @param array $collection_params List of parameters.
+		 */
 		$collection_params = apply_filters(
 			'experimental_woocommerce_analytics_variations_collection_params',
 			$this->get_collection_params()

--- a/src/API/Reports/Variations/Controller.php
+++ b/src/API/Reports/Variations/Controller.php
@@ -55,9 +55,12 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$args       = array();
-		$collection_params = apply_filters( 'internal_woocommerce_analytics_variations_collection_params', $this->get_collection_params() );
-		$registered = array_keys( $collection_params );
+		$args              = array();
+		$collection_params = apply_filters(
+			'experimental_woocommerce_analytics_variations_collection_params',
+			$this->get_collection_params()
+		);
+		$registered        = array_keys( $collection_params );
 		foreach ( $registered as $param_name ) {
 			if ( isset( $request[ $param_name ] ) ) {
 				if ( isset( $this->param_mapping[ $param_name ] ) ) {
@@ -397,7 +400,7 @@ class Controller extends ReportsController implements ExportableInterface {
 	 * @param array $status Stock status from report row.
 	 * @return string
 	 */
-	protected function _get_stock_status( $status ) {
+	protected function get_stock_status( $status ) {
 		$statuses = wc_get_product_stock_status_options();
 
 		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : '';
@@ -441,7 +444,7 @@ class Controller extends ReportsController implements ExportableInterface {
 		);
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
-			$export_item['stock_status'] = $this->_get_stock_status( $item['extended_info']['stock_status'] );
+			$export_item['stock_status'] = $this->get_stock_status( $item['extended_info']['stock_status'] );
 			$export_item['stock']        = $item['extended_info']['stock_quantity'];
 		}
 

--- a/src/API/Reports/Variations/Controller.php
+++ b/src/API/Reports/Variations/Controller.php
@@ -56,7 +56,8 @@ class Controller extends ReportsController implements ExportableInterface {
 	 */
 	public function get_items( $request ) {
 		$args       = array();
-		$registered = array_keys( $this->get_collection_params() );
+		$collection_params = apply_filters( 'internal_woocommerce_analytics_variations_collection_params', $this->get_collection_params() );
+		$registered = array_keys( $collection_params );
 		foreach ( $registered as $param_name ) {
 			if ( isset( $request[ $param_name ] ) ) {
 				if ( isset( $this->param_mapping[ $param_name ] ) ) {

--- a/src/API/Reports/Variations/DataStore.php
+++ b/src/API/Reports/Variations/DataStore.php
@@ -291,8 +291,17 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 		}
 	}
 
-	protected function should_exclude_simple_products( $query_args ) {
-		return apply_filters( 'internal_woocommerce_analytics_variations_should_exclude_simple_products', true, $query_args );
+	/**
+	 * Returns if simple products should be excluded from the report.
+	 *
+	 * @internal
+	 *
+	 * @param array $query_args Query parameters.
+	 *
+	 * @return boolean
+	 */
+	protected function should_exclude_simple_products( array $query_args ) {
+		return apply_filters( 'experimental_woocommerce_analytics_variations_should_exclude_simple_products', true, $query_args );
 	}
 
 	/**
@@ -340,12 +349,12 @@ class DataStore extends ReportsDataStore implements DataStoreInterface {
 				{$wpdb->prefix}wc_order_product_lookup as product_lookup
 				left join {$wpdb->prefix}woocommerce_order_items as order_items
 				on product_lookup.order_item_id = order_items.order_item_id
-			where 
-				{$where_clauses}	
-			group by 
-				product_lookup.product_id, 
-				product_lookup.variation_id, 
-				order_items.order_item_name				
+			where
+				{$where_clauses}
+			group by
+				product_lookup.product_id,
+				product_lookup.variation_id,
+				order_items.order_item_name
 		";
 
 		// phpcs:ignore

--- a/src/API/Reports/Variations/Stats/Controller.php
+++ b/src/API/Reports/Variations/Stats/Controller.php
@@ -64,8 +64,8 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 
-		$collection_params = apply_filters( 'internal_woocommerce_analytics_variations_stats_collection_params', $this->get_collection_params() );
-		$registered = array_keys( $collection_params );
+		$collection_params = apply_filters( 'experimental_woocommerce_analytics_variations_stats_collection_params', $this->get_collection_params() );
+		$registered        = array_keys( $collection_params );
 		foreach ( $registered as $param_name ) {
 			if ( isset( $request[ $param_name ] ) ) {
 				if ( isset( $this->param_mapping[ $param_name ] ) ) {

--- a/src/API/Reports/Variations/Stats/Controller.php
+++ b/src/API/Reports/Variations/Stats/Controller.php
@@ -63,7 +63,13 @@ class Controller extends \WC_REST_Reports_Controller {
 				'variations_count',
 			),
 		);
-
+		/**
+		 * Experimental: Filter the list of parameters provided when querying data from the data store.
+		 *
+		 * @ignore
+		 *
+		 * @param array $collection_params List of parameters.
+		 */
 		$collection_params = apply_filters( 'experimental_woocommerce_analytics_variations_stats_collection_params', $this->get_collection_params() );
 		$registered        = array_keys( $collection_params );
 		foreach ( $registered as $param_name ) {

--- a/src/API/Reports/Variations/Stats/Controller.php
+++ b/src/API/Reports/Variations/Stats/Controller.php
@@ -64,7 +64,8 @@ class Controller extends \WC_REST_Reports_Controller {
 			),
 		);
 
-		$registered = array_keys( $this->get_collection_params() );
+		$collection_params = apply_filters( 'internal_woocommerce_analytics_variations_stats_collection_params', $this->get_collection_params() );
+		$registered = array_keys( $collection_params );
 		foreach ( $registered as $param_name ) {
 			if ( isset( $request[ $param_name ] ) ) {
 				if ( isset( $this->param_mapping[ $param_name ] ) ) {

--- a/src/API/Reports/Variations/Stats/DataStore.php
+++ b/src/API/Reports/Variations/Stats/DataStore.php
@@ -83,7 +83,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		$included_variations = $this->get_included_variations( $query_args );
 		if ( $included_variations ) {
 			$products_where_clause .= " AND {$order_product_lookup_table}.variation_id IN ({$included_variations})";
-		} else if ( $this->should_exclude_simple_products( $query_args ) ) {
+		} elseif ( $this->should_exclude_simple_products( $query_args ) ) {
 			$products_where_clause .= " AND {$order_product_lookup_table}.variation_id != 0";
 		}
 
@@ -119,8 +119,17 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
 	}
 
-	protected function should_exclude_simple_products( $query_args ) {
-		return apply_filters( 'internal_woocommerce_analytics_variations_stats_should_exclude_simple_products', true, $query_args );
+	/**
+	 * Returns if simple products should be excluded from the report.
+	 *
+	 * @internal
+	 *
+	 * @param array $query_args Query parameters.
+	 *
+	 * @return boolean
+	 */
+	protected function should_exclude_simple_products( array $query_args ) {
+		return apply_filters( 'experimental_woocommerce_analytics_variations_stats_should_exclude_simple_products', true, $query_args );
 	}
 
 	/**

--- a/src/API/Reports/Variations/Stats/DataStore.php
+++ b/src/API/Reports/Variations/Stats/DataStore.php
@@ -83,7 +83,7 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		$included_variations = $this->get_included_variations( $query_args );
 		if ( $included_variations ) {
 			$products_where_clause .= " AND {$order_product_lookup_table}.variation_id IN ({$included_variations})";
-		} else {
+		} else if ( $this->should_exclude_simple_products( $query_args ) ) {
 			$products_where_clause .= " AND {$order_product_lookup_table}.variation_id != 0";
 		}
 
@@ -117,6 +117,10 @@ class DataStore extends VariationsDataStore implements DataStoreInterface {
 		$this->interval_query->add_sql_clause( 'where', $products_where_clause );
 		$this->interval_query->add_sql_clause( 'join', $products_from_clause );
 		$this->interval_query->add_sql_clause( 'select', $this->get_sql_clause( 'select' ) . ' AS time_interval' );
+	}
+
+	protected function should_exclude_simple_products( $query_args ) {
+		return apply_filters( 'internal_woocommerce_analytics_variations_stats_should_exclude_simple_products', true, $query_args );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a few experimental filters to allow simple products to be included in the Variations analytics report. 

No third-party extensions should make use of these filters, as they are experimental and subject to change/removal in a future version of WooCommerce Admin

They have been added only to allow for experimentation and testing of changes that may or may not be made in a future WooCommerce Admin version.

When these filters are not used, the Variations analytics report should be *identical* to how it was prior to the changes in this PR.

JS filters (see example extension to understand how these could be used):
* `experimental_woocommerce_admin_variations_report_table_title`: allows the Variations report table title to be modified
* `experimental_woocommerce_admin_variations_report_table_summary_variations_count_label`: allows the Variations report table "variations" count label to be modified

PHP filters (see example extension to understand how these could be used):
* `experimental_woocommerce_analytics_variations_collection_params` and `experimental_woocommerce_analytics_variations_stats_collection_params`: allow for additional params to be included in the query params that are passed through the REST API and to the data store. 
* `experimental_woocommerce_analytics_variations_should_exclude_simple_products` and `experimental_woocommerce_analytics_variations_stats_should_exclude_simple_products`: return `false` to include simple products. By default, returns `true`, which is the standard, non-experimental, behavior.

### Screenshots

#### Before

<img width="1280" alt="Screen Shot 2022-03-12 at 20 21 42" src="https://user-images.githubusercontent.com/2098816/158042171-cf756f78-188e-4f8d-a468-f21c0499232f.png">

#### After (changes enabled by example extension)

<img width="1280" alt="Screen Shot 2022-03-12 at 21 22 47" src="https://user-images.githubusercontent.com/2098816/158042174-022e481e-e5c5-4afa-a122-ccfba7833771.png">

### Detailed test instructions:

1. Run this branch.
2. Make sure you have some simple products and variations, as well as some orders containing both.
3. Verify that the Variations analytics report behaves identically as before the changes in this PR.
4. Install and activate the [products-and-variations-analytics-extension.zip](https://github.com/woocommerce/woocommerce-admin/files/8238876/products-and-variations-analytics-extension.zip) example extension.
5. Clear the Analytics cache (WooCommerce > Status > Tools > Clear analytics cache > Clear).
6. Verify that when anything other than the "Show: All simple products and variations" filter is selected, everything behaves as before.
7. Verify that when the "Show: All simple products and variations" filter is selected that both simple products and variations are included (see screen shot above for example).

### Changelog

No changelog needed, as these are experimental filters.

### References

- Project thread: pbIJXs-1e3-p2