### PR TITLE
Add `:preserveSemverRanges` to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-	"extends": [ "config:base" ],
+	"extends": [ "config:base", ":preserveSemverRanges" ],
 	"lockFileMaintenance": { "enabled": true },
 	"ignoreDeps": [ "phpunit/phpunit" ],
 	"schedule": [ "before 3am on wednesday" ],


### PR DESCRIPTION
Update `renovate.json` to preserve (but continue to upgrade) any existing SemVer ranges based on the conclusion of p90Yrv-2Qc-p2.

Reference:

- [`:preserveSemverRanges`](https://docs.renovatebot.com/presets-default/#preservesemverranges)
- [How to Use Preset Configs](https://docs.renovatebot.com/config-presets/#how-to-use-preset-configs)


no changelog