### PR TITLE
Fix industry tab not clickable after going back

### DIFF
--- a/changelogs/fix-8440-industry-tab-not-clicable
+++ b/changelogs/fix-8440-industry-tab-not-clicable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix industry tab not clickable after going back. #8469

--- a/client/profile-wizard/header.js
+++ b/client/profile-wizard/header.js
@@ -18,6 +18,7 @@ export default class ProfileWizardHeader extends Component {
 			showUnsavedChangesModal: false,
 		};
 		this.lastClickedStepKey = null;
+		this.onStepClick = this.onStepClick.bind( this );
 	}
 
 	shouldWarnForUnsavedChanges( step ) {
@@ -71,27 +72,28 @@ export default class ProfileWizardHeader extends Component {
 			( step ) => step.key === currentStep
 		);
 
-		visibleSteps.map( ( step, index ) => {
+		visibleSteps.forEach( ( step, index ) => {
 			const previousStep = visibleSteps[ index - 1 ];
+			step.isComplete = step.isComplete || index < currentStepIndex;
 
-			if ( index < currentStepIndex ) {
-				step.isComplete = true;
-			}
+			const canClickStepLabel =
+				! previousStep || previousStep.isComplete || step.isComplete;
 
-			if ( ! previousStep || previousStep.isComplete ) {
-				step.onClick = ( key ) => {
-					if ( this.shouldWarnForUnsavedChanges( currentStep ) ) {
-						this.setState( { showUnsavedChangesModal: true } );
-						this.lastClickedStepKey = key;
-					} else {
-						updateQueryString( { step: key } );
-					}
-				};
+			if ( canClickStepLabel ) {
+				step.onClick = this.onStepClick;
 			}
-			return step;
 		} );
-
 		return <Stepper steps={ visibleSteps } currentStep={ currentStep } />;
+	}
+
+	onStepClick( key ) {
+		const { currentStep } = this.props;
+		if ( this.shouldWarnForUnsavedChanges( currentStep ) ) {
+			this.setState( { showUnsavedChangesModal: true } );
+			this.lastClickedStepKey = key;
+		} else {
+			updateQueryString( { step: key } );
+		}
 	}
 
 	render() {

--- a/packages/admin-e2e-tests/CHANGELOG.md
+++ b/packages/admin-e2e-tests/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 -   Update all js packages with minor/patch version changes. #8392
 
+-   Add E2E test for checking onboarding tab clickable after going back. #8469
+
 # 0.1.2
 
 -   Add Customers to analytics pages tested #7573

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -66,6 +66,15 @@ const testAdminOnboardingWizard = () => {
 			await profileWizard.continue();
 		} );
 
+		it( 'can click industry tab after going back', async () => {
+			await profileWizard.goToOBWStep( 'Store Details' );
+			await profileWizard.storeDetails.isDisplayed();
+
+			await profileWizard.goToOBWStep( 'Industry' );
+			await profileWizard.industry.isDisplayed();
+			await profileWizard.continue();
+		} );
+
 		it( 'can complete the product types section', async () => {
 			await profileWizard.productTypes.isDisplayed( 7 );
 

--- a/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
+++ b/packages/admin-e2e-tests/src/specs/activate-and-setup/complete-onboarding-wizard.ts
@@ -67,11 +67,13 @@ const testAdminOnboardingWizard = () => {
 		} );
 
 		it( 'can click industry tab after going back', async () => {
+			await profileWizard.navigate();
 			await profileWizard.goToOBWStep( 'Store Details' );
 			await profileWizard.storeDetails.isDisplayed();
 
 			await profileWizard.goToOBWStep( 'Industry' );
 			await profileWizard.industry.isDisplayed();
+
 			await profileWizard.continue();
 		} );
 


### PR DESCRIPTION
Fixes #8440

This PR fixes the bug that the industry tab becomes unclickable when a user goes back to the Store Details step.

### Detailed test instructions:

- Go to Setup Wizard
- Go to the next step
- Click on the Store Details tab
- Confirm that Industry tab is clickable

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
