### PR TITLE
Add Reminder Bar for task list experiment

### DIFF
--- a/TESTING-INSTRUCTIONS.md
+++ b/TESTING-INSTRUCTIONS.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Display Reminder Bar while completing the primary task list
+
+1. Checkout branch on a fresh site (if your store is > 4 weeks old it will automatically hide the reminder bar)
+2. Complete the onboarding wizard with standard options.
+3. Complete a single step of the primary task list.
+4. You should _not_ see the reminder bar on the Homescreen or any other page related to the tasks. You _should_ see it everywhere else.
+5. Go to a  non-task related page, such as _Orders_, and you should see the bar appear above the header. Ensure the copy starts with "You're doing great!"
+6. Click the "Continue Setup" link, which should redirect you to the Homescreen.
+7. Complete all but one task remaining.
+8. Go back to the _Orders_ page to view the reminder bar. It should appear similar but have different copy, starting with "Almost there."
+9. Click the "Finish setup" link to ensure that it returns you to the homescreen. 
+10. Hide the list by clicking the '...' menu, and then return to the _Orders_ page. The bar should now be hidden. 
+11. Re-enable task list by going to Orders -> Help -> Setup Wizard -> Task List -> Enable. 
+12. The reminder bar should now appear when viewing the _Orders_ page.
+13. Complete the task list.
+14. The reminder bar will no longer display on the _Orders_ page. 
+
 ### Display WCPay task when installed via subscriptions option on profiler
 
 1. Start with a fresh install.

--- a/changelogs/add-8356-reminder-bar
+++ b/changelogs/add-8356-reminder-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Adding reminder bar for primary task list experiment(s)

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -22,6 +22,8 @@ import { TasksReminderBar } from '../tasks';
 
 export const PAGE_TITLE_FILTER = 'woocommerce_admin_header_page_title';
 
+// TODO: Height logic not applying to Tasks reminder bar, move to another slot?
+
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );
 	const siteTitle = getSetting( 'siteTitle', '' );
@@ -95,7 +97,11 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 
 	return (
 		<div className={ className } ref={ headerElement }>
-			<TasksReminderBar taskListId="setup_experiment_1" />
+			{ /* TODO: Task List ID? */ }
+			<TasksReminderBar
+				taskListId="setup_experiment_1"
+				pageTitle={ pageTitle }
+			/>
 			<div className="woocommerce-layout__header-wrapper">
 				<WooHeaderNavigationItem.Slot
 					fillProps={ { isEmbedded, query } }

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -18,6 +18,7 @@ import {
 	WooHeaderItem,
 	WooHeaderPageTitle,
 } from './utils';
+import { TasksReminderBar } from '../tasks';
 
 export const PAGE_TITLE_FILTER = 'woocommerce_admin_header_page_title';
 
@@ -94,6 +95,7 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 
 	return (
 		<div className={ className } ref={ headerElement }>
+			<TasksReminderBar taskListId="setup_experiment_1" />
 			<div className="woocommerce-layout__header-wrapper">
 				<WooHeaderNavigationItem.Slot
 					fillProps={ { isEmbedded, query } }

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -93,12 +93,17 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 		}
 	}, [ isEmbedded, sections, siteTitle ] );
 
+	const tasksReminderFeature =
+		window.wcAdminFeatures[ 'tasklist-setup-experiment-1' ];
+
 	return (
 		<div className={ className } ref={ headerElement }>
-			<TasksReminderBar
-				pageTitle={ pageTitle }
-				updateBodyMargin={ updateBodyMargin }
-			/>
+			{ tasksReminderFeature && (
+				<TasksReminderBar
+					pageTitle={ pageTitle }
+					updateBodyMargin={ updateBodyMargin }
+				/>
+			) }
 			<div className="woocommerce-layout__header-wrapper">
 				<WooHeaderNavigationItem.Slot
 					fillProps={ { isEmbedded, query } }

--- a/client/header/index.js
+++ b/client/header/index.js
@@ -22,8 +22,6 @@ import { TasksReminderBar } from '../tasks';
 
 export const PAGE_TITLE_FILTER = 'woocommerce_admin_header_page_title';
 
-// TODO: Height logic not applying to Tasks reminder bar, move to another slot?
-
 export const Header = ( { sections, isEmbedded = false, query } ) => {
 	const headerElement = useRef( null );
 	const siteTitle = getSetting( 'siteTitle', '' );
@@ -97,10 +95,9 @@ export const Header = ( { sections, isEmbedded = false, query } ) => {
 
 	return (
 		<div className={ className } ref={ headerElement }>
-			{ /* TODO: Task List ID? */ }
 			<TasksReminderBar
-				taskListId="setup_experiment_1"
 				pageTitle={ pageTitle }
+				updateBodyMargin={ updateBodyMargin }
 			/>
 			<div className="woocommerce-layout__header-wrapper">
 				<WooHeaderNavigationItem.Slot

--- a/client/tasks/index.ts
+++ b/client/tasks/index.ts
@@ -6,4 +6,5 @@ import './fills';
 import './deprecated-tasks';
 
 export * from './placeholder';
+export * from './reminder-bar';
 export default Tasks;

--- a/client/tasks/reminder-bar/index.tsx
+++ b/client/tasks/reminder-bar/index.tsx
@@ -1,0 +1,1 @@
+export * from './reminder-bar';

--- a/client/tasks/reminder-bar/reminder-bar.scss
+++ b/client/tasks/reminder-bar/reminder-bar.scss
@@ -1,16 +1,29 @@
-.woocommerce-layout__header-tasks-reminder {
+.woocommerce-layout__header-tasks-reminder-bar {
 	height: 40px;
 	background-color: #007cba;
 	display: flex;
-	justify-content: center;
+	justify-content: space-between;
 	align-items: center;
+	color: #fff;
+
+	&:before {
+		content: '';
+	}
+
+	button {
+		&:hover {
+			opacity: 0.7;
+			color: inherit;
+		}
+
+		color: inherit;
+	}
 
 	a {
-		color: #fff;
+		color: inherit;
 	}
 
 	p {
 		font-size: 13px;
-		color: #fff;
 	}
 }

--- a/client/tasks/reminder-bar/reminder-bar.scss
+++ b/client/tasks/reminder-bar/reminder-bar.scss
@@ -1,0 +1,16 @@
+.woocommerce-layout__header-tasks-reminder {
+	height: 40px;
+	background-color: #007cba;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	a {
+		color: #fff;
+	}
+
+	p {
+		font-size: 13px;
+		color: #fff;
+	}
+}

--- a/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/client/tasks/reminder-bar/reminder-bar.tsx
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { ONBOARDING_STORE_NAME, TaskListType } from '@woocommerce/data';
+import { Link } from '@woocommerce/components';
+import { getAdminLink } from '@woocommerce/settings';
+import interpolateComponents from '@automattic/interpolate-components';
+
+/**
+ * Internal dependencies
+ */
+import './reminder-bar.scss';
+
+type ReminderBarProps = {
+	taskListId: string;
+};
+
+type ReminderTextProps = {
+	remainingCount: number | null;
+};
+
+const ReminderText: React.FC< ReminderTextProps > = ( { remainingCount } ) => {
+	if ( typeof remainingCount !== 'number' ) {
+		return null;
+	}
+
+	const translationText =
+		remainingCount === 1
+			? /* translators: 1: remaining tasks count */
+			  __(
+					'🎉 Almost there. Only {{strongText}}%1$d step left{{/strongText}} get your store up and running. {{setupLink}}Finish setup{{/setupLink}}',
+					'woocommerce-admin'
+			  )
+			: /* translators: 1: remaining tasks count */
+			  __(
+					"🚀 You're doing great! {{strongText}}%1$d steps left{{/strongText}} to get your store up and running. {{setupLink}}Continue setup{{/setupLink}}",
+					'woocommerce-admin'
+			  );
+
+	return (
+		<p>
+			{ interpolateComponents( {
+				mixedString: sprintf( translationText, remainingCount ),
+				components: {
+					strongText: <strong />,
+					setupLink: (
+						<Link
+							href={ getAdminLink( 'admin.php?page=wc-admin' ) }
+							type="wp-admin"
+						/>
+					),
+				},
+			} ) }
+		</p>
+	);
+};
+
+export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
+	taskListId,
+} ) => {
+	const { remainingCount, loading } = useSelect( ( select ) => {
+		const { getTaskList, hasFinishedResolution } = select(
+			ONBOARDING_STORE_NAME
+		);
+		const taskList: TaskListType = getTaskList( taskListId );
+		const isResolved = hasFinishedResolution( 'getTaskList', [
+			taskListId,
+		] );
+		const nowTimestamp = Date.now();
+		const visibleTasks = taskList?.tasks.filter(
+			( task ) =>
+				! task.isDismissed &&
+				( ! task.isSnoozed || task.snoozedUntil < nowTimestamp )
+		);
+
+		const completedTasks = visibleTasks?.filter(
+			( task ) => task.isComplete
+		).length;
+
+		return {
+			loading: ! isResolved,
+			remainingCount: isResolved
+				? visibleTasks?.length - completedTasks
+				: null,
+		};
+	} );
+
+	if ( loading ) {
+		return null;
+	}
+
+	return (
+		<div className="woocommerce-layout__header-tasks-reminder">
+			<ReminderText remainingCount={ remainingCount } />
+		</div>
+	);
+};

--- a/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/client/tasks/reminder-bar/reminder-bar.tsx
@@ -27,7 +27,7 @@ type ReminderBarProps = {
 };
 
 type ReminderTextProps = {
-	remainingCount: number | null;
+	remainingCount: number;
 };
 
 const REMINDER_BAR_HIDDEN_OPTION = 'woocommerce_task_list_reminder_bar_hidden';

--- a/client/tasks/reminder-bar/reminder-bar.tsx
+++ b/client/tasks/reminder-bar/reminder-bar.tsx
@@ -15,8 +15,6 @@ import { close as closeIcon } from '@wordpress/icons';
 import interpolateComponents from '@automattic/interpolate-components';
 import { useEffect } from '@wordpress/element';
 
-// TODO: Automatically hide after 4 weeks
-
 /**
  * Internal dependencies
  */
@@ -78,6 +76,7 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 		taskListHidden,
 		taskListComplete,
 		reminderBarHidden,
+		completedTasksCount,
 	} = useSelect( ( select ) => {
 		const {
 			getTaskList,
@@ -114,24 +113,26 @@ export const TasksReminderBar: React.FC< ReminderBarProps > = ( {
 			taskListHidden: isResolved ? taskList.isHidden : false,
 			taskListComplete: isResolved ? taskList.isComplete : false,
 			loading: ! isResolved,
+			completedTasksCount: completedTasks,
 			remainingCount: isResolved
 				? visibleTasks?.length - completedTasks
 				: null,
 		};
 	} );
 
-	const displayReminderBar =
+	const hideReminderBar =
 		loading ||
 		taskListHidden ||
 		taskListComplete ||
 		reminderBarHidden ||
+		completedTasksCount === 0 ||
 		[ 'Home', 'Shipping', 'Tax', 'Payments' ].includes( pageTitle );
 
 	useEffect( () => {
 		updateBodyMargin();
-	}, [ displayReminderBar, updateBodyMargin ] );
+	}, [ hideReminderBar, updateBodyMargin ] );
 
-	if ( displayReminderBar ) {
+	if ( hideReminderBar ) {
 		return null;
 	}
 

--- a/packages/data/src/onboarding/types.ts
+++ b/packages/data/src/onboarding/types.ts
@@ -12,6 +12,7 @@ export type TaskType = {
 	snoozedUntil: number;
 	time: string;
 	title: string;
+	isVisited?: boolean;
 };
 
 export type TaskListType = {

--- a/packages/data/src/onboarding/types.ts
+++ b/packages/data/src/onboarding/types.ts
@@ -19,6 +19,7 @@ export type TaskListType = {
 	id: string;
 	isCollapsible?: boolean;
 	isComplete: boolean;
+	isHidden: boolean;
 	isExpandable?: boolean;
 	tasks: TaskType[];
 	title: string;

--- a/src/Features/OnboardingTasks/TaskList.php
+++ b/src/Features/OnboardingTasks/TaskList.php
@@ -6,6 +6,8 @@
 namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\WooCommerce\Admin\WCAdminHelper;
+
 
 /**
  * Task List class.
@@ -25,6 +27,11 @@ class TaskList {
 	 * Option name of completed task lists.
 	 */
 	const COMPLETED_OPTION = 'woocommerce_task_list_completed_lists';
+
+	/**
+	 * Option name of hidden reminder bar.
+	 */
+	const REMINDER_BAR_HIDDEN_OPTION = 'woocommerce_task_list_reminder_bar_hidden';
 
 	/**
 	 * ID.
@@ -114,6 +121,8 @@ class TaskList {
 			$task  = new $class( $this );
 			$this->add_task( $task );
 		}
+
+		$this->possibly_remove_reminder_bar();
 	}
 
 	/**
@@ -309,6 +318,20 @@ class TaskList {
 			return $this->event_prefix . $event_name;
 		}
 		return $this->get_list_id() . '_tasklist_' . $event_name;
+	}
+
+	/**
+	 * Remove reminder bar four weeks after store creation.
+	 */
+	public static function possibly_remove_reminder_bar() {
+		$bar_hidden            = get_option( self::REMINDER_BAR_HIDDEN_OPTION, 'no' );
+		$active_for_four_weeks = WCAdminHelper::is_wc_admin_active_for( WEEK_IN_SECONDS * 4 );
+
+		if ( 'yes' === $bar_hidden || ! $active_for_four_weeks ) {
+			return;
+		}
+
+		update_option( self::REMINDER_BAR_HIDDEN_OPTION, 'yes' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32161 

This is the implementation of the reminder bar described in [this issue](woocommerce/woocommerce#32161). It will display on top of the header on a subset of pages, only when the task list is visible, and direct the user back to the task list.

**Notes:**
- This is currently manually assigned to use the task list with ID `setup_experiment_1`. We may need to add logic to this as we put together the experiment.
- I've currently got this functionality behind the `tasklist-setup-experiment-1` feature flag, which will also be consolidated as we implement the experiment in another issue.
- This is added inside the preexisting `<Header />` component to leverage the scroll and top margin logic that already existed. 

**Also note that I won't be around to merge or respond to feedback, so I'll need someone else to do so.**

### Screenshots

![image](https://user-images.githubusercontent.com/444632/158713210-3df0e13d-300e-4fe8-bfdf-42507471eaf8.png)

### Detailed test instructions:

-   Checkout branch on a fresh site (if your store is > 4 weeks old it will automatically hide the reminder bar)
- Enable the `tasklist-setup-experiment-1` feature flag.
- Complete the OBW
-  Complete a single step of the primary task list.
- You should _not_ see the reminder bar on the Homescreen or any other page related to the tasks. You should see it everywhere else.
- Go to a  non-task related page, such as _Orders_, and you should see the bar appear above the header. Ensure the copy starts with "You're doing great!"
- Click the link, which should redirect you to the Homescreen.
- Complete all but one task remaining.
- Go back to the _Orders_ (or otherwise) page to view the reminder bar. It should appear similar but have different copy, starting with "Almost there."
- Click the link again to ensure that it returns you to the homescreen. 
- Hide the list by clicking the `..`' menu, and then return to the _Orders_ page. The bar should now not be displayed. 
- Re-enable task list by going to Orders->Help->Setup Wizard->Task List -> Enable. 
- The reminder bar should now reappear when viewing the _Orders_ page.
- Complete the task list.
- The reminder bar will no longer display on the _Orders_ page. 