### PR TITLE
Fix `jsdoc/check-line-alignment` eslint warnings

### DIFF
--- a/client/activity-panel/panels/help.js
+++ b/client/activity-panel/panels/help.js
@@ -355,9 +355,9 @@ function getListItems( props ) {
 	 * Filter an array of help items for the setup task.
 	 *
 	 * @filter woocommerce_admin_setup_task_help_items
-	 * @param {Array.<Object>} items Array items object based on task.
-	 * @param {('products'|'appearance'|'shipping'|'tax'|'payments'|'marketing')} task url query parameters.
-	 * @param {Object} props React component props.
+	 * @param {Array.<Object>}                                                    items Array items object based on task.
+	 * @param {('products'|'appearance'|'shipping'|'tax'|'payments'|'marketing')} task  url query parameters.
+	 * @param {Object}                                                            props React component props.
 	 */
 	const filteredItems = applyFilters(
 		SETUP_TASK_HELP_ITEMS_FILTER,

--- a/client/analytics/components/report-error/index.js
+++ b/client/analytics/components/report-error/index.js
@@ -9,7 +9,7 @@ import { EmptyContent } from '@woocommerce/components';
  * Component to render when there is an error in a report component due to data
  * not being loaded or being invalid.
  *
- * @param {Object} props React props.
+ * @param {Object} props             React props.
  * @param {string} [props.className] Additional class name to style the component.
  */
 function ReportError( { className } ) {

--- a/client/analytics/components/report-table/index.js
+++ b/client/analytics/components/report-table/index.js
@@ -162,13 +162,13 @@ const ReportTable = ( props ) => {
 		 * Enables manipulation of data used to create the report CSV.
 		 *
 		 * @filter woocommerce_admin_report_table
-		 * @param {Object} reportTableData - data used to create the table.
+		 * @param {Object} reportTableData          - data used to create the table.
 		 * @param {string} reportTableData.endpoint - table api endpoint.
-		 * @param {Array} reportTableData.headers - table headers data.
-		 * @param {Array} reportTableData.rows - table rows data.
-		 * @param {Object} reportTableData.totals - total aggregates for request.
-		 * @param {Array} reportTableData.summary - summary numbers data.
-		 * @param {Object} reportTableData.items - response from api requerst.
+		 * @param {Array}  reportTableData.headers  - table headers data.
+		 * @param {Array}  reportTableData.rows     - table rows data.
+		 * @param {Object} reportTableData.totals   - total aggregates for request.
+		 * @param {Array}  reportTableData.summary  - summary numbers data.
+		 * @param {Object} reportTableData.items    - response from api requerst.
 		 */
 		return applyFilters( TABLE_FILTER, {
 			endpoint,

--- a/client/analytics/report/categories/config.js
+++ b/client/analytics/report/categories/config.js
@@ -58,8 +58,8 @@ export const charts = applyFilters( CATEGORY_REPORT_CHARTS_FILTER, [
  * Category Report Advanced Filters.
  *
  * @filter woocommerce_admin_category_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/coupons/config.js
+++ b/client/analytics/report/coupons/config.js
@@ -49,8 +49,8 @@ export const charts = applyFilters( COUPON_REPORT_CHARTS_FILTER, [
  * Coupons Report Advanced Filters.
  *
  * @filter woocommerce_admin_coupon_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/customers/config.js
+++ b/client/analytics/report/customers/config.js
@@ -79,8 +79,8 @@ export const filters = applyFilters( CUSTOMERS_REPORT_FILTERS_FILTER, [
  * Customers Report Advanced Filters.
  *
  * @filter woocommerce_admin_customers_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/downloads/config.js
+++ b/client/analytics/report/downloads/config.js
@@ -69,8 +69,8 @@ export const filters = applyFilters( DOWLOADS_REPORT_FILTERS_FILTER, [
  * Downloads Report Advanced Filters.
  *
  * @filter woocommerce_admin_downloads_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/get-reports.js
+++ b/client/analytics/report/get-reports.js
@@ -134,10 +134,10 @@ export default () => {
 	 * An object defining a report page.
 	 *
 	 * @typedef {Object} report
-	 * @property {string} report Report slug.
-	 * @property {string} title Report title.
-	 * @property {Node} component React Component to render.
-	 * @property {Object} navArgs Arguments supplied to WooCommerce Navigation.
+	 * @property {string} report    Report slug.
+	 * @property {string} title     Report title.
+	 * @property {Node}   component React Component to render.
+	 * @property {Object} navArgs   Arguments supplied to WooCommerce Navigation.
 	 */
 
 	/**

--- a/client/analytics/report/index.js
+++ b/client/analytics/report/index.js
@@ -25,22 +25,22 @@ import getReports from './get-reports';
  * An object defining a chart.
  *
  * @typedef {Object} chart
- * @property {string} key Chart slug.
- * @property {string} label Chart label.
- * @property {string} order Default way to order the `orderby` property.
- * @property {string} orderby Column by which to order.
- * @property {('number'|'currency')} type Specify the type of number.
+ * @property {string}                key     Chart slug.
+ * @property {string}                label   Chart label.
+ * @property {string}                order   Default way to order the `orderby` property.
+ * @property {string}                orderby Column by which to order.
+ * @property {('number'|'currency')} type    Specify the type of number.
  */
 
 /**
  * An object defining a set of report filters.
  *
  * @typedef {Object} filter
- * @property {string} label Label describing the set of filters.
- * @property {string} param Url query param this set of filters operates on.
+ * @property {string}         label        Label describing the set of filters.
+ * @property {string}         param        Url query param this set of filters operates on.
  * @property {Array.<string>} staticParams Array of `param` that remain constant when other params are manipulated.
- * @property {Function} showFilters A function with url query as an argument returning a Boolean depending on whether or not the filters should be shown.
- * @property {Array} filters An array of filter objects.
+ * @property {Function}       showFilters  A function with url query as an argument returning a Boolean depending on whether or not the filters should be shown.
+ * @property {Array}          filters      An array of filter objects.
  */
 
 /**

--- a/client/analytics/report/orders/config.js
+++ b/client/analytics/report/orders/config.js
@@ -89,8 +89,8 @@ export const filters = applyFilters( ORDERS_REPORT_FILTERS_FILTER, [
  * Orders Report Advanced Filters.
  *
  * @filter woocommerce_admin_orders_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/products/config.js
+++ b/client/analytics/report/products/config.js
@@ -183,8 +183,8 @@ const variationsConfig = {
  * Produts Report Advanced Filters.
  *
  * @filter woocommerce_admin_products_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/revenue/config.js
+++ b/client/analytics/report/revenue/config.js
@@ -89,8 +89,8 @@ export const charts = applyFilters( REVENUE_REPORT_CHARTS_FILTER, [
  * Revenue Report Advanced Filters.
  *
  * @filter woocommerce_admin_revenue_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/revenue/table.js
+++ b/client/analytics/report/revenue/table.js
@@ -293,8 +293,8 @@ RevenueReportTable.contextType = CurrencyContext;
  *
  * @param {boolean} isError
  * @param {boolean} isRequesting
- * @param {Object} tableQuery
- * @param {Object} revenueData
+ * @param {Object}  tableQuery
+ * @param {Object}  revenueData
  * @return {Object} formatted tableData prop
  */
 const formatProps = memoize(

--- a/client/analytics/report/stock/config.js
+++ b/client/analytics/report/stock/config.js
@@ -14,8 +14,8 @@ export const showDatePicker = false;
  * Stock Report Advanced Filters.
  *
  * @filter woocommerce_admin_stock_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/taxes/config.js
+++ b/client/analytics/report/taxes/config.js
@@ -65,8 +65,8 @@ export const charts = applyFilters( TAXES_REPORT_CHARTS_FILTER, [
  * Taxes Report Advanced Filters.
  *
  * @filter woocommerce_admin_taxes_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/variations/config.js
+++ b/client/analytics/report/variations/config.js
@@ -141,8 +141,8 @@ export const filters = applyFilters( VARIATIONS_REPORT_FILTERS_FILTER, [
  * Variations Report Advanced Filters.
  *
  * @filter woocommerce_admin_variations_report_advanced_filters
- * @param {Object} advancedFilters Report Advanced Filters.
- * @param {string} advancedFilters.title Interpolated component string for Advanced Filters title.
+ * @param {Object} advancedFilters         Report Advanced Filters.
+ * @param {string} advancedFilters.title   Interpolated component string for Advanced Filters title.
  * @param {Object} advancedFilters.filters An object specifying a report's Advanced Filters.
  */
 export const advancedFilters = applyFilters(

--- a/client/analytics/report/variations/table.js
+++ b/client/analytics/report/variations/table.js
@@ -211,9 +211,9 @@ class VariationsReportTable extends Component {
 				 *
 				 * @filter experimental_woocommerce_admin_variations_report_table_summary_variations_count_label
 				 *
-				 * @param {string} label Label used for the count.
+				 * @param {string} label           Label used for the count.
 				 * @param {string} variationsCount Number of variations.
-				 * @param {Array} query Query parameters.
+				 * @param {Array}  query           Query parameters.
 				 */
 				label: applyFilters(
 					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_SUMMARY_VARIATIONS_COUNT_LABEL_FILTER,
@@ -305,7 +305,7 @@ class VariationsReportTable extends Component {
 				 * @filter experimental_woocommerce_admin_variations_report_table_title
 				 *
 				 * @param {string} title Title used for the report table.
-				 * @param {Array} query Query parameters.
+				 * @param {Array}  query Query parameters.
 				 */
 				title={ applyFilters(
 					EXPERIMENTAL_VARIATIONS_REPORT_TABLE_TITLE_FILTER,

--- a/client/analytics/settings/historical-data/status.js
+++ b/client/analytics/settings/historical-data/status.js
@@ -14,14 +14,14 @@ function HistoricalDataStatus( { importDate, status } ) {
 	 *
 	 * @filter woocommerce_admin_import_status
 	 *
-	 * @param {Object} statuses Import statuses.
-	 * @param {string} statuses.nothing Nothing to import.
-	 * @param {string} statuses.ready Ready to import.
-	 * @param {Array} statuses.initializing Initializing string and spinner.
-	 * @param {Array} statuses.customers Importing customers string and spinner.
-	 * @param {Array} statuses.orders Importing orders string and spinner.
-	 * @param {Array} statuses.finalizing Finalizing string and spinner.
-	 * @param {string} statuses.finished Message displayed after import.
+	 * @param {Object} statuses              Import statuses.
+	 * @param {string} statuses.nothing      Nothing to import.
+	 * @param {string} statuses.ready        Ready to import.
+	 * @param {Array}  statuses.initializing Initializing string and spinner.
+	 * @param {Array}  statuses.customers    Importing customers string and spinner.
+	 * @param {Array}  statuses.orders       Importing orders string and spinner.
+	 * @param {Array}  statuses.finalizing   Finalizing string and spinner.
+	 * @param {string} statuses.finished     Message displayed after import.
 	 */
 	const statusLabels = applyFilters( HISTORICAL_DATA_STATUS_FILTER, {
 		nothing: __( 'Nothing To Import', 'woocommerce-admin' ),

--- a/client/dashboard/components/settings/general/store-address.tsx
+++ b/client/dashboard/components/settings/general/store-address.tsx
@@ -29,7 +29,7 @@ type Option = { key: string; label: string };
  * Check if a given address field is required for the locale.
  *
  * @param {string} fieldName Name of the field to check.
- * @param {Object} locale Locale data.
+ * @param {Object} locale    Locale data.
  * @return {boolean} Field requirement.
  */
 export function isAddressFieldRequired(
@@ -147,7 +147,7 @@ export const normalizeState = ( state: string ): string => {
 /**
  * Get state filter
  *
- * @param {string} isStateAbbreviation Whether to use state abbreviation or not.
+ * @param {string} isStateAbbreviation     Whether to use state abbreviation or not.
  * @param {string} normalizedAutofillState The value of the autofillState field.
  * @return {Function} filter function.
  */
@@ -189,9 +189,9 @@ export const getStateFilter = (
 /**
  * Get the autofill countryState fields and set value from filtered options.
  *
- * @param {Array} options Array of filterable options.
- * @param {string} countryState The value of the countryState field.
- * @param {Function} setValue Set value of the countryState input.
+ * @param {Array}    options      Array of filterable options.
+ * @param {string}   countryState The value of the countryState field.
+ * @param {Function} setValue     Set value of the countryState input.
  * @return {Object} React component.
  */
 export function useGetCountryStateAutofill(
@@ -328,9 +328,9 @@ type StoreAddressProps = {
 /**
  * Store address fields.
  *
- * @param {Object} props Props for input components.
+ * @param {Object}   props               Props for input components.
  * @param {Function} props.getInputProps Get input props.
- * @param {Function} props.setValue Set value of the countryState input.
+ * @param {Function} props.setValue      Set value of the countryState input.
  * @return {Object} -
  */
 export function StoreAddress( {

--- a/client/dashboard/default-sections.js
+++ b/client/dashboard/default-sections.js
@@ -45,11 +45,11 @@ const DEFAULT_SECTIONS_FILTER = 'woocommerce_dashboard_default_sections';
  * An object defining a dashboard section.
  *
  * @typedef {Object} section
- * @property {string} key Unique identifying string.
- * @property {Node} component React component to render.
- * @property {string} title Title.
- * @property {boolean} isVisible The default visibilty.
- * @property {Node} icon Section icon.
+ * @property {string}         key          Unique identifying string.
+ * @property {Node}           component    React component to render.
+ * @property {string}         title        Title.
+ * @property {boolean}        isVisible    The default visibilty.
+ * @property {Node}           icon         Section icon.
  * @property {Array.<string>} hiddenBlocks Blocks that are hidden by default.
  */
 

--- a/client/dashboard/utils.js
+++ b/client/dashboard/utils.js
@@ -40,10 +40,10 @@ export function getCurrencyRegion( countryState ) {
 /**
  * Gets the product IDs for items based on the product types and theme selected in the onboarding profiler.
  *
- * @param {Object} productTypes Product Types.
- * @param {Object} profileItems Onboarding profile.
+ * @param {Object}  productTypes          Product Types.
+ * @param {Object}  profileItems          Onboarding profile.
  * @param {boolean} includeInstalledItems Include installed items in returned product IDs.
- * @param {Array} installedPlugins Installed plugins.
+ * @param {Array}   installedPlugins      Installed plugins.
  * @return {Array} Product Ids.
  */
 export function getProductIdsForCart(
@@ -67,9 +67,9 @@ export function getProductIdsForCart(
 /**
  * Gets the labeled/categorized product names and types for items based on the product types and theme selected in the onboarding profiler.
  *
- * @param {Object} productTypes Product Types.
- * @param {Object} profileItems Onboarding profile.
- * @param {Array} installedPlugins Installed plugins.
+ * @param {Object} productTypes     Product Types.
+ * @param {Object} profileItems     Onboarding profile.
+ * @param {Array}  installedPlugins Installed plugins.
  * @return {Array} Objects with labeled/categorized product names and types.
  */
 export function getCategorizedOnboardingProducts(
@@ -114,10 +114,10 @@ export function getCategorizedOnboardingProducts(
 /**
  * Gets a product list for items based on the product types and theme selected in the onboarding profiler.
  *
- * @param {Object} profileItems Onboarding profile.
+ * @param {Object}  profileItems          Onboarding profile.
  * @param {boolean} includeInstalledItems Include installed items in returned product list.
- * @param {Array} installedPlugins Installed plugins.
- * @param {Object} productTypes Product Types.
+ * @param {Array}   installedPlugins      Installed plugins.
+ * @param {Object}  productTypes          Product Types.
  * @return {Array} Products.
  */
 export function getProductList(

--- a/client/embedded-body-layout/embedded-body-layout.tsx
+++ b/client/embedded-body-layout/embedded-body-layout.tsx
@@ -42,7 +42,7 @@ export const EmbeddedBodyLayout = () => {
 	 *
 	 * @filter woocommerce_admin_embedded_layout_components
 	 * @param {Array.<Node>} embeddedBodyComponentList Array of body components.
-	 * @param {Object} query url query parameters.
+	 * @param {Object}       query                     url query parameters.
 	 */
 	const componentList = applyFilters(
 		'woocommerce_admin_embedded_layout_components',

--- a/client/header/utils.js
+++ b/client/header/utils.js
@@ -7,9 +7,9 @@ import { cloneElement } from '@wordpress/element';
 /**
  * Ordered header item.
  *
- * @param {Node} children - Node children.
- * @param {number} order - Node order.
- * @param {Array} props - Fill props.
+ * @param {Node}   children - Node children.
+ * @param {number} order    - Node order.
+ * @param {Array}  props    - Fill props.
  * @return {Node} Node.
  */
 const createOrderedChildren = ( children, order, props ) => {
@@ -33,8 +33,8 @@ const createOrderedChildren = ( children, order, props ) => {
  * scope: 'woocommerce-admin',
  * } );
  * @param {Object} param0
- * @param {Array} param0.children - Node children.
- * @param {Array} param0.order - Node order.
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
  */
 export const WooHeaderItem = ( { children, order = 1 } ) => {
 	return (
@@ -72,8 +72,8 @@ WooHeaderItem.Slot = ( { fillProps } ) => (
  * scope: 'woocommerce-admin',
  * } );
  * @param {Object} param0
- * @param {Array} param0.children - Node children.
- * @param {Array} param0.order - Node order.
+ * @param {Array}  param0.children - Node children.
+ * @param {Array}  param0.order    - Node order.
  */
 export const WooHeaderNavigationItem = ( { children, order = 1 } ) => {
 	return (
@@ -110,7 +110,7 @@ WooHeaderNavigationItem.Slot = ( { fillProps } ) => (
  * 	scope: 'woocommerce-admin',
  * } );
  * @param {Object} param0
- * @param {Array} param0.children - Node children.
+ * @param {Array}  param0.children - Node children.
  */
 export const WooHeaderPageTitle = ( { children } ) => {
 	return <Fill name={ 'woocommerce_header_page_title' }>{ children }</Fill>;

--- a/client/hooks/useFocusOutside.js
+++ b/client/hooks/useFocusOutside.js
@@ -80,8 +80,8 @@ function isFocusNormalizedButton( eventTarget ) {
  * A react hook that can be used to check whether focus has moved outside the
  * element the event handlers are bound to.
  *
- * @param {EventCallback} onFocusOutside        A callback triggered when focus moves outside
- *                                              the element the event handlers are bound to.
+ * @param {EventCallback} onFocusOutside A callback triggered when focus moves outside
+ *                                       the element the event handlers are bound to.
  *
  * @return {FocusOutsideReturnValue} An object containing event handlers. Bind the event handlers
  *                                   to a wrapping element element to capture when focus moves

--- a/client/inbox-panel/utils.js
+++ b/client/inbox-panel/utils.js
@@ -7,7 +7,7 @@ import GraphemeSplitter from 'grapheme-splitter';
 /**
  * Get the count of the unread notes from the received list.
  *
- * @param {Array} notes - List of notes, contains read and unread notes.
+ * @param {Array}  notes    - List of notes, contains read and unread notes.
  * @param {number} lastRead - The timestamp that the user read a note.
  * @return {number} - Unread notes count.
  */
@@ -46,8 +46,8 @@ export function hasValidNotes( notes ) {
 /**
  * Truncates array of text characters.
  *
- * @param {Array} letters The letter array to truncate.
- * @param {number} limit number of characters to limit to
+ * @param {Array}  letters   The letter array to truncate.
+ * @param {number} limit     number of characters to limit to
  * @param {string} separator The separator string to truncate to.
  */
 export const truncate = ( letters, limit, separator = ' ' ) => {
@@ -68,7 +68,7 @@ export const truncate = ( letters, limit, separator = ' ' ) => {
  * Currently does not count <br> as a character even though it should.
  *
  * @param {HTMLElement} element HTML element
- * @param {number} limit number of characters to limit to
+ * @param {number}      limit   number of characters to limit to
  */
 const truncateElement = ( element, limit ) => {
 	const truncatedNode = document.createElement( 'div' );
@@ -108,7 +108,7 @@ const truncateElement = ( element, limit ) => {
  * Truncates characters from a HTML string excluding markup. Truncated strings will be appended with ellipsis.
  *
  * @param {string} originalHTML HTML string
- * @param {number} limit number of characters to limit to
+ * @param {number} limit        number of characters to limit to
  */
 export const truncateRenderableHTML = ( originalHTML, limit ) => {
 	const tempNode = document.createElement( 'div' );

--- a/client/layout/controller.js
+++ b/client/layout/controller.js
@@ -303,9 +303,9 @@ export class Controller extends Component {
  * Update an anchor's link in sidebar to include persisted queries. Leave excluded screens
  * as is.
  *
- * @param {HTMLElement} item - Sidebar anchor link.
- * @param {Object} nextQuery - A query object to be added to updated hrefs.
- * @param {Array} excludedScreens - wc-admin screens to avoid updating.
+ * @param {HTMLElement} item            - Sidebar anchor link.
+ * @param {Object}      nextQuery       - A query object to be added to updated hrefs.
+ * @param {Array}       excludedScreens - wc-admin screens to avoid updating.
  */
 export function updateLinkHref( item, nextQuery, excludedScreens ) {
 	if ( isWCAdmin( item.href ) ) {

--- a/client/layout/transient-notices/snackbar/list.js
+++ b/client/layout/transient-notices/snackbar/list.js
@@ -15,12 +15,12 @@ import Snackbar from './';
 /**
  * Renders a list of notices.
  *
- * @param  {Object}   $0           Props passed to the component.
- * @param  {Array}    $0.notices   Array of notices to render.
- * @param  {Function} $0.onRemove  Function called when a notice should be removed / dismissed.
- * @param  {Function} $0.onRemove2 Function called when a notice should be removed / dismissed.
- * @param  {Object}   $0.className Name of the class used by the component.
- * @param  {Object}   $0.children  Array of children to be rendered inside the notice list.
+ * @param {Object}   $0           Props passed to the component.
+ * @param {Array}    $0.notices   Array of notices to render.
+ * @param {Function} $0.onRemove  Function called when a notice should be removed / dismissed.
+ * @param {Function} $0.onRemove2 Function called when a notice should be removed / dismissed.
+ * @param {Object}   $0.className Name of the class used by the component.
+ * @param {Object}   $0.children  Array of children to be rendered inside the notice list.
  * @return {Object}                The rendered notices list.
  */
 function SnackbarList( {

--- a/client/lib/async-requests/index.js
+++ b/client/lib/async-requests/index.js
@@ -17,8 +17,8 @@ import { getAdminSetting } from '~/utils/admin-settings';
  * Get a function that accepts ids as they are found in url parameter and
  * returns a promise with an optional method applied to results
  *
- * @param {string|Function} path - api path string or a function of the query returning api path string
- * @param {Function} [handleData] - function applied to each iteration of data
+ * @param {string|Function} path         - api path string or a function of the query returning api path string
+ * @param {Function}        [handleData] - function applied to each iteration of data
  * @return {Function} - a function of ids returning a promise
  */
 export function getRequestByIdString( path, handleData = identity ) {
@@ -90,9 +90,9 @@ export const getTaxRateLabels = getRequestByIdString(
  * Create a variation name by concatenating each of the variation's
  * attribute option strings.
  *
- * @param {Object} variation - variation returned by the api
- * @param {Array} variation.attributes - attribute objects, with option property.
- * @param {string} variation.name - name of variation.
+ * @param {Object} variation            - variation returned by the api
+ * @param {Array}  variation.attributes - attribute objects, with option property.
+ * @param {string} variation.name       - name of variation.
  * @return {string} - formatted variation name
  */
 export function getVariationName( { attributes, name } ) {

--- a/client/lib/collections/index.js
+++ b/client/lib/collections/index.js
@@ -1,8 +1,8 @@
 /**
  * Returns an object with items grouped by the sent key.
  *
- * @param {Array} array array of objects.
- * @param {string} key the object prop that will be used to group elements.
+ * @param {Array}  array      array of objects.
+ * @param {string} key        the object prop that will be used to group elements.
  * @param {string} defaultKey if the key is not found in the object, it will use this value.
  * @return {Object} Object that contains the grouped elements.
  */
@@ -30,7 +30,7 @@ export const groupListOfObjectsBy = (
 /**
  * Returns a (shallow) copy of an object with all its props set to the specified value
  *
- * @param {*} obj the Object to copy.
+ * @param {*} obj   the Object to copy.
  * @param {*} value the value to set all props on the object to.
  */
 export const setAllPropsToValue = ( obj, value ) => {

--- a/client/lib/currency-context.js
+++ b/client/lib/currency-context.js
@@ -18,7 +18,7 @@ export const getFilteredCurrencyInstance = ( query ) => {
 	 *
 	 * @filter woocommerce_admin_report_currency
 	 * @param {Object} config Currency configuration.
-	 * @param {Object} query Url query parameters.
+	 * @param {Object} query  Url query parameters.
 	 */
 	const filteredConfig = applyFilters(
 		'woocommerce_admin_report_currency',

--- a/client/lib/get-selected-chart/index.js
+++ b/client/lib/get-selected-chart/index.js
@@ -8,7 +8,7 @@ import { find } from 'lodash';
  * of charts. If the chart is not found it will return the first chart.
  *
  * @param {string} chartName - the name of the chart to get configuration for
- * @param {Array} charts - list of charts for a particular report
+ * @param {Array}  charts    - list of charts for a particular report
  * @return {Object} - chart configuration object
  */
 export default function getSelectedChart( chartName, charts = [] ) {

--- a/client/lib/order-values/tax.js
+++ b/client/lib/order-values/tax.js
@@ -22,7 +22,7 @@ export function getOrderDiscountTax( order ) {
  * Get the total tax for a given line item's value
  *
  * @param {Object} order An order as returned from API
- * @param {number} id The ID of the line_item
+ * @param {number} id    The ID of the line_item
  * @return {number} Tax amount as a decimal number
  */
 export function getOrderLineItemTax( order, id ) {
@@ -35,7 +35,7 @@ export function getOrderLineItemTax( order, id ) {
  * Get the total tax for a given fee
  *
  * @param {Object} order An order as returned from API
- * @param {number} id The ID of a fee line in this order
+ * @param {number} id    The ID of a fee line in this order
  * @return {number} Tax amount as a decimal number
  */
 export function getOrderFeeTax( order, id ) {

--- a/client/lib/order-values/totals.js
+++ b/client/lib/order-values/totals.js
@@ -22,7 +22,7 @@ export function getOrderDiscountTotal( order ) {
  * Get the value for a single fee on a given order
  *
  * @param {Object} order An order as returned from API
- * @param {number} id The ID of the fee_line
+ * @param {number} id    The ID of the fee_line
  * @return {number} The total fee amount as a decimal number
  */
 export function getOrderFeeCost( order, id ) {
@@ -52,7 +52,7 @@ export function getOrderFeeTotal( order ) {
  * Get the individual price for a given item, pre-discounts.
  *
  * @param {Object} order An order as returned from API
- * @param {number} id The ID of the line_item
+ * @param {number} id    The ID of the line_item
  * @return {number} Total amount as a decimal number
  */
 export function getOrderItemCost( order, id ) {

--- a/client/navigation/utils.ts
+++ b/client/navigation/utils.ts
@@ -192,7 +192,7 @@ export const sortMenuItems = ( menuItems: Item[] ): Item[] => {
 /**
  * Get a flat tree structure of all Categories and thier children grouped by menuId
  *
- * @param {Array} menuItems Array of menu items.
+ * @param {Array}    menuItems      Array of menu items.
  * @param {Function} currentUserCan Callback method passed the capability to determine if a menu item is visible.
  * @return {Object} Mapped menu items and categories.
  */

--- a/client/profile-wizard/index.js
+++ b/client/profile-wizard/index.js
@@ -102,10 +102,10 @@ class ProfileWizard extends Component {
 	 * Set the initial and current values of a step to track the state of the step.
 	 * This is used to determine if the step has been changes or not.
 	 *
-	 * @param {string} step key of the step
-	 * @param {*} initialValues the initial values of the step
-	 * @param {*} currentValues the current values of the step
-	 * @param {Function} onSave a function to call when the step is saved
+	 * @param {string}   step          key of the step
+	 * @param {*}        initialValues the initial values of the step
+	 * @param {*}        currentValues the current values of the step
+	 * @param {Function} onSave        a function to call when the step is saved
 	 */
 	trackStepValueChanges( step, initialValues, currentValues, onSave ) {
 		this.stepValueChanges[ step ] = {
@@ -118,8 +118,8 @@ class ProfileWizard extends Component {
 	/**
 	 * Update currentValues of the given step.
 	 *
-	 * @param {string} step key of the step
-	 * @param {*} currentValues the current values of the step
+	 * @param {string} step          key of the step
+	 * @param {*}      currentValues the current values of the step
 	 */
 	updateCurrentStepValues( step, currentValues ) {
 		if ( ! this.stepValueChanges[ step ] ) {

--- a/client/profile-wizard/steps/theme/uploader.js
+++ b/client/profile-wizard/steps/theme/uploader.js
@@ -22,8 +22,8 @@ import { isWpVersion } from '@woocommerce/settings';
 /**
  * NOTE: This can be removed after WP version 6.0 and replaced with a div.
  *
- * @param {Object} props React props.
- * @param {Node} [props.children] Children of react component.
+ * @param {Object} props             React props.
+ * @param {Node}   [props.children]  Children of react component.
  * @param {string} [props.className] Additional class name to style the component.
  */
 const DropZoneWrapper = ( { children, className } ) => {

--- a/client/store-management-links/index.js
+++ b/client/store-management-links/index.js
@@ -163,8 +163,8 @@ export const StoreManagementLinks = () => {
 		 * An object defining an extension link.
 		 *
 		 * @typedef {Object} link
-		 * @property {Node} icon Icon to render.
-		 * @property {string} href Url.
+		 * @property {Node}   icon  Icon to render.
+		 * @property {string} href  Url.
 		 * @property {string} title Link title.
 		 */
 

--- a/client/tasks/fills/products/product-template-modal.js
+++ b/client/tasks/fills/products/product-template-modal.js
@@ -137,8 +137,8 @@ export default function ProductTemplateModal( { onClose } ) {
 	 * An object defining a product template.
 	 *
 	 * @typedef {Object} template
-	 * @property {string} key Icon to render.
-	 * @property {string} title Url.
+	 * @property {string} key      Icon to render.
+	 * @property {string} title    Url.
 	 * @property {string} subtitle Link title.
 	 */
 

--- a/client/tasks/fills/tax/utils.ts
+++ b/client/tasks/fills/tax/utils.ts
@@ -12,10 +12,10 @@ export const AUTOMATION_PLUGINS = [ 'jetpack', 'woocommerce-services' ];
 /**
  * Check if a store has a complete address given general settings.
  *
- * @param {Object} generalSettings General settings.
- * @param {Object} generalSettings.woocommerce_store_address Store address.
+ * @param {Object} generalSettings                             General settings.
+ * @param {Object} generalSettings.woocommerce_store_address   Store address.
  * @param {Object} generalSettings.woocommerce_default_country Store default country.
- * @param {Object} generalSettings.woocommerce_store_postcode Store postal code.
+ * @param {Object} generalSettings.woocommerce_store_postcode  Store postal code.
  */
 export const hasCompleteAddress = ( generalSettings: {
 	woocommerce_store_address?: string;

--- a/client/utils/admin-settings.js
+++ b/client/utils/admin-settings.js
@@ -20,15 +20,15 @@ const ADMIN_SETTINGS_SOURCE = Object.keys( adminSettings ).reduce(
 /**
  * Retrieves a setting value from the setting state.
  *
- * @param {string}   name                         The identifier for the setting.
- * @param {*}    [fallback=false]             The value to use as a fallback
- *                                                if the setting is not in the
- *                                                state.
- * @param {Function} [filter=( val ) => val]  	  A callback for filtering the
- *                                                value before it's returned.
- *                                                Receives both the found value
- *                                                (if it exists for the key) and
- *                                                the provided fallback arg.
+ * @param {string}   name                    The identifier for the setting.
+ * @param {*}        [fallback=false]        The value to use as a fallback
+ *                                           if the setting is not in the
+ *                                           state.
+ * @param {Function} [filter=( val ) => val] A callback for filtering the
+ *                                           value before it's returned.
+ *                                           Receives both the found value
+ *                                           (if it exists for the key) and
+ *                                           the provided fallback arg.
  *
  * @return {*}  The value present in the settings state for the given
  *                   name.
@@ -65,12 +65,12 @@ export const ORDER_STATUSES = getAdminSetting( 'orderStatuses' );
  *
  * @deprecated
  *
- * @param {string}   name                        The setting property key for the
- *                                               setting being mutated.
- * @param {*}    value                       The value to set.
- * @param {Function} [filter=( val ) => val]     Allows for providing a callback
- *                                               to sanitize the setting (eg.
- *                                               ensure it's a number)
+ * @param {string}   name                    The setting property key for the
+ *                                           setting being mutated.
+ * @param {*}        value                   The value to set.
+ * @param {Function} [filter=( val ) => val] Allows for providing a callback
+ *                                           to sanitize the setting (eg.
+ *                                           ensure it's a number)
  */
 export function setAdminSetting( name, value, filter = ( val ) => val ) {
 	if ( mutableSources.includes( name ) ) {

--- a/client/utils/enqueue-script.js
+++ b/client/utils/enqueue-script.js
@@ -1,9 +1,9 @@
 /**
  * Adds a script to the page if it has not already been loaded. JS version of `wp_enqueue_script`.
  *
- * @param {Object} script WP_Script
+ * @param {Object} script        WP_Script
  * @param {string} script.handle Script handle.
- * @param {string} script.src Script URL.
+ * @param {string} script.src    Script URL.
  */
 export function enqueueScript( script ) {
 	return new Promise( ( resolve, reject ) => {

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -46,7 +46,7 @@ export function getScreenName() {
 /**
  * Similar to filter, but return two arrays separated by a partitioner function
  *
- * @param {Array} arr - Original array of values.
+ * @param {Array}    arr         - Original array of values.
  * @param {Function} partitioner - Function to return truthy/falsy values to separate items in array.
  *
  * @return {Array} - Array of two arrays, first including truthy values, and second including falsy.

--- a/packages/admin-e2e-tests/src/utils/actions.ts
+++ b/packages/admin-e2e-tests/src/utils/actions.ts
@@ -34,7 +34,7 @@ const waitForTimeout = async ( timeout: number ) => {
 /**
  * Publish, verify that item was published. Trash, verify that item was trashed.
  *
- * @param {string} button (Publish)
+ * @param {string} button              (Publish)
  * @param {string} publishNotice
  * @param {string} publishVerification
  */

--- a/packages/components/src/chart/d3chart/utils/axis-x.js
+++ b/packages/components/src/chart/d3chart/utils/axis-x.js
@@ -21,7 +21,7 @@ const mostPoints = 31;
  * Calculate the maximum number of ticks allowed in the x-axis based on the width and mode of the chart
  *
  * @param {number} width - calculated page width
- * @param {string} mode - item-comparison or time-comparison
+ * @param {string} mode  - item-comparison or time-comparison
  * @return {number} number of x-axis ticks based on width and chart mode
  */
 const calculateMaxXTicks = ( width, mode ) => {
@@ -102,8 +102,8 @@ const getFactors = ( inputNum ) => {
 /**
  * Calculates the increment factor between ticks so there aren't more than maxTicks.
  *
- * @param {Array} uniqueDates - all the unique dates from the input data for the chart
- * @param {number} maxTicks - maximum number of ticks that can be displayed in the x-axis
+ * @param {Array}  uniqueDates - all the unique dates from the input data for the chart
+ * @param {number} maxTicks    - maximum number of ticks that can be displayed in the x-axis
  * @return {number} x-axis ticks increment factor
  */
 const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
@@ -123,7 +123,7 @@ const calculateXTicksIncrementFactor = ( uniqueDates, maxTicks ) => {
 /**
  * Get x-axis ticks given the unique dates and the increment factor.
  *
- * @param {Array} uniqueDates - all the unique dates from the input data for the chart
+ * @param {Array}  uniqueDates     - all the unique dates from the input data for the chart
  * @param {number} incrementFactor - increment factor for the visible ticks.
  * @return {Array} Ticks for the x-axis.
  */
@@ -145,10 +145,10 @@ const getXTicksFromIncrementFactor = ( uniqueDates, incrementFactor ) => {
 /**
  * Returns ticks for the x-axis.
  *
- * @param {Array} uniqueDates - all the unique dates from the input data for the chart
- * @param {number} width - calculated page width
- * @param {string} mode - item-comparison or time-comparison
- * @param {string} interval - string of the interval used in the graph (hour, day, week...)
+ * @param {Array}  uniqueDates - all the unique dates from the input data for the chart
+ * @param {number} width       - calculated page width
+ * @param {string} mode        - item-comparison or time-comparison
+ * @param {string} interval    - string of the interval used in the graph (hour, day, week...)
  * @return {number} number of x-axis ticks based on width and chart mode
  */
 export const getXTicks = ( uniqueDates, width, mode, interval ) => {
@@ -180,8 +180,8 @@ export const getXTicks = ( uniqueDates, width, mode, interval ) => {
 /**
  * Compares 2 strings and returns a list of words that are unique from s2
  *
- * @param {string} s1 - base string to compare against
- * @param {string} s2 - string to compare against the base string
+ * @param {string}        s1        - base string to compare against
+ * @param {string}        s2        - string to compare against the base string
  * @param {string|Object} splitChar - character or RegExp to use to deliminate words
  * @return {Array} of unique words that appear in s2 but not in s1, the base string
  */

--- a/packages/components/src/chart/d3chart/utils/index.js
+++ b/packages/components/src/chart/d3chart/utils/index.js
@@ -8,8 +8,8 @@ import { utcParse as d3UTCParse } from 'd3-time-format';
 /**
  * Allows an overriding formatter or defaults to d3Format or d3TimeFormat
  *
- * @param {string|Function} format - either a format string for the D3 formatters or an overriding fomatting method
- * @param {Function} formatter - default d3Format or another formatting method, which accepts the string `format`
+ * @param {string|Function} format    - either a format string for the D3 formatters or an overriding fomatting method
+ * @param {Function}        formatter - default d3Format or another formatting method, which accepts the string `format`
  * @return {Function} to be used to format an input given the format and formatter
  */
 export const getFormatter = ( format, formatter = d3Format ) =>
@@ -51,7 +51,7 @@ export const getOrderedKeys = ( data ) => {
 /**
  * Describes `getUniqueDates`
  *
- * @param {Array} data - the chart component's `data` prop.
+ * @param {Array}  data       - the chart component's `data` prop.
  * @param {string} dateParser - D3 time format
  * @return {Array} an array of unique date values sorted from earliest to latest
  */
@@ -64,7 +64,7 @@ export const getUniqueDates = ( data, dateParser ) => {
 /**
  * Check whether data is empty.
  *
- * @param {Array} data - the chart component's `data` prop.
+ * @param {Array}  data      - the chart component's `data` prop.
  * @param {number} baseValue - base value to test data values against.
  * @return {boolean} `false` if there was at least one data value different than
  * the baseValue.

--- a/packages/components/src/chart/d3chart/utils/line-chart.js
+++ b/packages/components/src/chart/d3chart/utils/line-chart.js
@@ -14,11 +14,11 @@ import { smallBreak, wideBreak } from './breakpoints';
 /**
  * Describes getDateSpaces
  *
- * @param {Array} data - The chart component's `data` prop.
- * @param {Array} uniqueDates - from `getUniqueDates`
- * @param {Array} visibleKeys - visible keys from the input data for the chart
- * @param {number} width - calculated width of the charting space
- * @param {Function} xScale - from `getXLineScale`
+ * @param {Array}    data        - The chart component's `data` prop.
+ * @param {Array}    uniqueDates - from `getUniqueDates`
+ * @param {Array}    visibleKeys - visible keys from the input data for the chart
+ * @param {number}   width       - calculated width of the charting space
+ * @param {Function} xScale      - from `getXLineScale`
  * @return {Array} that includes the date, start (x position) and width to mode the mouseover rectangles
  */
 export const getDateSpaces = (
@@ -82,7 +82,7 @@ export const getLine = ( xScale, yScale ) =>
 /**
  * Describes `getLineData`
  *
- * @param {Array} data - The chart component's `data` prop.
+ * @param {Array} data        - The chart component's `data` prop.
  * @param {Array} orderedKeys - from `getOrderedKeys`.
  * @return {Array} an array objects with a category `key` and an array of `values` with `date` and `value` properties
  */

--- a/packages/components/src/chart/d3chart/utils/scales.js
+++ b/packages/components/src/chart/d3chart/utils/scales.js
@@ -11,10 +11,10 @@ import moment from 'moment';
 /**
  * Describes getXScale
  *
- * @param {Array} uniqueDates - from `getUniqueDates`
- * @param {number} width - calculated width of the charting space
- * @param {boolean} compact - whether the chart must be compact (without padding
- between days)
+ * @param {Array}   uniqueDates - from `getUniqueDates`
+ * @param {number}  width       - calculated width of the charting space
+ * @param {boolean} compact     - whether the chart must be compact (without padding
+                                between days)
  * @return {Function} a D3 scale of the dates
  */
 export const getXScale = ( uniqueDates, width, compact = false ) =>
@@ -26,10 +26,10 @@ export const getXScale = ( uniqueDates, width, compact = false ) =>
 /**
  * Describes getXGroupScale
  *
- * @param {Array} orderedKeys - from `getOrderedKeys`
- * @param {Function} xScale - from `getXScale`
- * @param {boolean} compact - whether the chart must be compact (without padding
- between days)
+ * @param {Array}    orderedKeys - from `getOrderedKeys`
+ * @param {Function} xScale      - from `getXScale`
+ * @param {boolean}  compact     - whether the chart must be compact (without padding
+                                 between days)
  * @return {Function} a D3 scale for each category within the xScale range
  */
 export const getXGroupScale = ( orderedKeys, xScale, compact = false ) =>
@@ -43,8 +43,8 @@ export const getXGroupScale = ( orderedKeys, xScale, compact = false ) =>
 /**
  * Describes getXLineScale
  *
- * @param {Array} uniqueDates - from `getUniqueDates`
- * @param {number} width - calculated width of the charting space
+ * @param {Array}  uniqueDates - from `getUniqueDates`
+ * @param {number} width       - calculated width of the charting space
  * @return {Function} a D3 scaletime for each date
  */
 export const getXLineScale = ( uniqueDates, width ) =>
@@ -139,8 +139,8 @@ export const getYScaleLimits = ( data ) => {
  * Describes getYScale
  *
  * @param {number} height - calculated height of the charting space
- * @param {number} yMin - minimum y value
- * @param {number} yMax - maximum y value
+ * @param {number} yMin   - minimum y value
+ * @param {number} yMax   - maximum y value
  * @return {Function} the D3 linear scale from 0 to the value from `getYMax`
  */
 export const getYScale = ( height, yMin, yMax ) =>

--- a/packages/components/src/compare-filter/button.js
+++ b/packages/components/src/compare-filter/button.js
@@ -9,12 +9,12 @@ import { createElement } from '@wordpress/element';
 /**
  * A button used when comparing items, if `count` is less than 2 a hoverable tooltip is added with `helpText`.
  *
- * @param {Object} props
- * @param {string} props.className
- * @param {number} props.count
- * @param {Node} props.children
- * @param {boolean} props.disabled
- * @param {string} props.helpText
+ * @param {Object}   props
+ * @param {string}   props.className
+ * @param {number}   props.count
+ * @param {Node}     props.children
+ * @param {boolean}  props.disabled
+ * @param {string}   props.helpText
  * @param {Function} props.onClick
  * @return {Object} -
  */

--- a/packages/components/src/ellipsis-menu/menu-title.js
+++ b/packages/components/src/ellipsis-menu/menu-title.js
@@ -9,7 +9,7 @@ import { createElement } from '@wordpress/element';
  * (so this should not be used in place of the `EllipsisMenu` prop `label`).
  *
  * @param {Object} props
- * @param {Node} props.children
+ * @param {Node}   props.children
  * @return {Object} -
  */
 const MenuTitle = ( { children } ) => {

--- a/packages/components/src/flag/index.js
+++ b/packages/components/src/flag/index.js
@@ -10,11 +10,11 @@ import { createElement } from '@wordpress/element';
 /**
  * Use the `Flag` component to display a country's flag using the operating system's emojis.
  *
- * @param {Object} props
- * @param {string} props.code
- * @param {Object} props.order
- * @param {string} props.className
- * @param {string} props.size
+ * @param {Object}  props
+ * @param {string}  props.code
+ * @param {Object}  props.order
+ * @param {string}  props.className
+ * @param {string}  props.size
  * @param {boolean} props.hideFromScreenReader
  * @return {Object} - React component.
  */

--- a/packages/components/src/order-status/index.js
+++ b/packages/components/src/order-status/index.js
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
 /**
  * Use `OrderStatus` to display a badge with human-friendly text describing the current order status.
  *
- * @param {Object} props
- * @param {Object} props.order
- * @param {string} props.order.status
- * @param {string} props.className
- * @param {Object} props.orderStatusMap
+ * @param {Object}  props
+ * @param {Object}  props.order
+ * @param {string}  props.order.status
+ * @param {string}  props.className
+ * @param {Object}  props.orderStatusMap
  * @param {boolean} props.labelPositionToLeft
  * @return {Object} -
  */

--- a/packages/components/src/search-list-control/hierarchy.js
+++ b/packages/components/src/search-list-control/hierarchy.js
@@ -6,8 +6,8 @@ import { forEach, groupBy, keyBy } from 'lodash';
 /**
  * Returns terms in a tree form.
  *
- * @param {Array} filteredList  Array of terms, possibly a subset of all terms, in flat format.
- * @param {Array} list  Array of the full list of terms, defaults to the filteredList.
+ * @param {Array} filteredList Array of terms, possibly a subset of all terms, in flat format.
+ * @param {Array} list         Array of the full list of terms, defaults to the filteredList.
  *
  * @return {Array} Array of terms in tree format.
  */

--- a/packages/components/src/search/autocompleters/attributes.js
+++ b/packages/components/src/search/autocompleters/attributes.js
@@ -56,7 +56,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,15 +77,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/categories.js
+++ b/packages/components/src/search/autocompleters/categories.js
@@ -56,7 +56,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,15 +77,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/countries.js
+++ b/packages/components/src/search/autocompleters/countries.js
@@ -55,7 +55,7 @@ import Flag from '../../flag';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -67,7 +67,7 @@ import Flag from '../../flag';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -76,15 +76,15 @@ import Flag from '../../flag';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 // Cache countries to avoid repeated requests.

--- a/packages/components/src/search/autocompleters/coupons.js
+++ b/packages/components/src/search/autocompleters/coupons.js
@@ -56,7 +56,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,15 +77,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/customers.js
+++ b/packages/components/src/search/autocompleters/customers.js
@@ -56,7 +56,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,15 +77,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/download-ips.js
+++ b/packages/components/src/search/autocompleters/download-ips.js
@@ -54,7 +54,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -66,7 +66,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -75,15 +75,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/emails.js
+++ b/packages/components/src/search/autocompleters/emails.js
@@ -54,7 +54,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -66,7 +66,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -75,15 +75,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/orders.js
+++ b/packages/components/src/search/autocompleters/orders.js
@@ -54,7 +54,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -66,7 +66,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -75,15 +75,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/product.js
+++ b/packages/components/src/search/autocompleters/product.js
@@ -57,7 +57,7 @@ import ProductImage from '../../product-image';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -69,7 +69,7 @@ import ProductImage from '../../product-image';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -78,15 +78,15 @@ import ProductImage from '../../product-image';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 /**
  * A products completer.

--- a/packages/components/src/search/autocompleters/taxes.js
+++ b/packages/components/src/search/autocompleters/taxes.js
@@ -56,7 +56,7 @@ import { computeSuggestionMatch, getTaxCode } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import { computeSuggestionMatch, getTaxCode } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,15 +77,15 @@ import { computeSuggestionMatch, getTaxCode } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/usernames.js
+++ b/packages/components/src/search/autocompleters/usernames.js
@@ -54,7 +54,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -66,7 +66,7 @@ import { computeSuggestionMatch } from './utils';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -75,15 +75,15 @@ import { computeSuggestionMatch } from './utils';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**

--- a/packages/components/src/search/autocompleters/utils.js
+++ b/packages/components/src/search/autocompleters/utils.js
@@ -9,7 +9,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Used to display matched partial in bold.
  *
  * @param {string} suggestion The item's label as returned from the API.
- * @param {string} query The search term to match in the string.
+ * @param {string} query      The search term to match in the string.
  * @return {Object} A list in three parts: before, match, and after.
  */
 export function computeSuggestionMatch( suggestion, query ) {

--- a/packages/components/src/search/autocompleters/variable-product.js
+++ b/packages/components/src/search/autocompleters/variable-product.js
@@ -53,7 +53,7 @@ import productsAutocompleter from './product';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -65,7 +65,7 @@ import productsAutocompleter from './product';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -74,15 +74,15 @@ import productsAutocompleter from './product';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 /**
  * A variable products completer.

--- a/packages/components/src/search/autocompleters/variations.js
+++ b/packages/components/src/search/autocompleters/variations.js
@@ -56,7 +56,7 @@ import ProductImage from '../../product-image';
 /**
  * @typedef {Object} OptionCompletion
  * @property {'insert-at-caret'|'replace'} action the intended placement of the completion.
- * @property {OptionCompletionValue} value the completion value.
+ * @property {OptionCompletionValue}       value  the completion value.
  */
 
 /**
@@ -68,7 +68,7 @@ import ProductImage from '../../product-image';
 /**
  * @callback FnGetOptionCompletion
  * @param {CompleterOption} value the value of the completer option.
- * @param {string} query the text value of the autocomplete query.
+ * @param {string}          query the text value of the autocomplete query.
  *
  * @return {(OptionCompletion|OptionCompletionValue)} the completion for the given option. If an
  * 													   OptionCompletionValue is returned, the
@@ -77,24 +77,24 @@ import ProductImage from '../../product-image';
 
 /**
  * @typedef {Object} WPCompleter
- * @property {string} name a way to identify a completer, useful for selective overriding.
- * @property {?string} className A class to apply to the popup menu.
- * @property {string} triggerPrefix the prefix that will display the menu.
- * @property {(CompleterOption[]|FnGetOptions)} options the completer options or a function to get them.
- * @property {?FnGetOptionKeywords} getOptionKeywords get the keywords for a given option.
- * @property {?FnIsOptionDisabled} isOptionDisabled get whether or not the given option is disabled.
- * @property {FnGetOptionLabel} getOptionLabel get the label for a given option.
- * @property {?FnAllowContext} allowContext filter the context under which the autocomplete activates.
- * @property {FnGetOptionCompletion} getOptionCompletion get the completion associated with a given option.
+ * @property {string}                           name                a way to identify a completer, useful for selective overriding.
+ * @property {?string}                          className           A class to apply to the popup menu.
+ * @property {string}                           triggerPrefix       the prefix that will display the menu.
+ * @property {(CompleterOption[]|FnGetOptions)} options             the completer options or a function to get them.
+ * @property {?FnGetOptionKeywords}             getOptionKeywords   get the keywords for a given option.
+ * @property {?FnIsOptionDisabled}              isOptionDisabled    get whether or not the given option is disabled.
+ * @property {FnGetOptionLabel}                 getOptionLabel      get the label for a given option.
+ * @property {?FnAllowContext}                  allowContext        filter the context under which the autocomplete activates.
+ * @property {FnGetOptionCompletion}            getOptionCompletion get the completion associated with a given option.
  */
 
 /**
  * Create a variation name by concatenating each of the variation's
  * attribute option strings.
  *
- * @param {Object} variation - variation returned by the api
- * @param {Array} variation.attributes - attribute objects, with option property.
- * @param {string} variation.name - name of variation.
+ * @param {Object} variation            - variation returned by the api
+ * @param {Array}  variation.attributes - attribute objects, with option property.
+ * @param {string} variation.name       - name of variation.
  * @return {string} - formatted variation name
  */
 function getVariationName( { attributes, name } ) {

--- a/packages/components/src/section/section.js
+++ b/packages/components/src/section/section.js
@@ -12,10 +12,10 @@ import { Level } from './context';
 /**
  * The section wrapper, used to indicate a sub-section (and change the header level context).
  *
- * @param {Object} props
+ * @param {Object}                         props
  * @param {import('react').ComponentType=} props.component
- * @param {import('react').ReactNode} props.children Children to render in the tip.
- * @param {string=} props.className
+ * @param {import('react').ReactNode}      props.children  Children to render in the tip.
+ * @param {string=}                        props.className
  * @return {JSX.Element} -
  */
 export function Section( { component, children, ...props } ) {

--- a/packages/components/src/summary/index.js
+++ b/packages/components/src/summary/index.js
@@ -17,7 +17,7 @@ import Menu from './menu';
  * the mobile format on smaller screens.
  *
  * @param {Object} props
- * @param {Node} props.children
+ * @param {Node}   props.children
  * @param {string} props.isDropdownBreakpoint
  * @param {string} props.label
  * @return {Object} -

--- a/packages/components/src/summary/number.js
+++ b/packages/components/src/summary/number.js
@@ -19,21 +19,21 @@ import { Text } from '../experimental';
 /**
  * A component to show a value, label, and optionally a change percentage and children node. Can also act as a link to a specific report focus.
  *
- * @param {Object} props
- * @param {Node} props.children
- * @param {number} props.delta Change percentage. Float precision is rendered as given.
- * @param {string} props.href
- * @param {string} props.hrefType
- * @param {boolean} props.isOpen
- * @param {string} props.label
- * @param {string} props.labelTooltipText
- * @param {Function} props.onToggle
- * @param {string} props.prevLabel
+ * @param {Object}        props
+ * @param {Node}          props.children
+ * @param {number}        props.delta               Change percentage. Float precision is rendered as given.
+ * @param {string}        props.href
+ * @param {string}        props.hrefType
+ * @param {boolean}       props.isOpen
+ * @param {string}        props.label
+ * @param {string}        props.labelTooltipText
+ * @param {Function}      props.onToggle
+ * @param {string}        props.prevLabel
  * @param {number|string} props.prevValue
- * @param {boolean} props.reverseTrend
- * @param {boolean} props.selected
+ * @param {boolean}       props.reverseTrend
+ * @param {boolean}       props.selected
  * @param {number|string} props.value
- * @param {Function} props.onLinkClickCallback
+ * @param {Function}      props.onLinkClickCallback
  * @return {Object} -
  */
 const SummaryNumber = ( {

--- a/packages/components/src/table/empty.js
+++ b/packages/components/src/table/empty.js
@@ -10,7 +10,7 @@ import { createElement } from '@wordpress/element';
  * It mimics the same height a table would have according to the `numberOfRows` prop.
  *
  * @param {Object} props
- * @param {Node} props.children
+ * @param {Node}   props.children
  * @param {number} props.numberOfRows
  * @return {Object} -
  */

--- a/packages/components/src/table/summary.js
+++ b/packages/components/src/table/summary.js
@@ -8,7 +8,7 @@ import { createElement } from '@wordpress/element';
  * A component to display summarized table data - the list of data passed in on a single line.
  *
  * @param {Object} props
- * @param {Array} props.data
+ * @param {Array}  props.data
  * @return {Object} -
  */
 const TableSummary = ( { data } ) => {

--- a/packages/components/src/tag/index.js
+++ b/packages/components/src/tag/index.js
@@ -14,14 +14,14 @@ import { withInstanceId } from '@wordpress/compose';
  * This component can be used to show an item styled as a "tag", optionally with an `X` + "remove"
  * or with a popover that is shown on click.
  *
- * @param {Object} props
+ * @param {Object}        props
  * @param {number|string} props.id
- * @param {string}props.instanceId
- * @param {string} props.label
- * @param {Object} props.popoverContents
- * @param {Function} props.remove
- * @param {string} props.screenReaderLabel
- * @param {string} props.className
+ * @param {string}        props.instanceId
+ * @param {string}        props.label
+ * @param {Object}        props.popoverContents
+ * @param {Function}      props.remove
+ * @param {string}        props.screenReaderLabel
+ * @param {string}        props.className
  * @return {Object} -
  */
 const Tag = ( {

--- a/packages/components/src/view-more-list/index.js
+++ b/packages/components/src/view-more-list/index.js
@@ -14,7 +14,7 @@ import Tag from '../tag';
  * This component displays a 'X more' button that displays a list of items on a popover when clicked.
  *
  * @param {Object} props
- * @param {Array} props.items
+ * @param {Array}  props.items
  * @return {Object} -
  */
 const ViewMoreList = ( { items } ) => {

--- a/packages/csv-export/src/index.js
+++ b/packages/csv-export/src/index.js
@@ -51,8 +51,8 @@ function getCSVRows( rows ) {
 /**
  * Generates a CSV string from table contents
  *
- * @param   {Array.<Object>}        headers    Object with table header information
- * @param   {Array.Array.<Object>}  rows       Object with table rows information
+ * @param {Array.<Object>}       headers Object with table header information
+ * @param {Array.Array.<Object>} rows    Object with table rows information
  * @return {string}                           Table contents in a CSV format
  */
 export function generateCSVDataFromTable( headers, rows ) {
@@ -65,8 +65,8 @@ export function generateCSVDataFromTable( headers, rows ) {
  * Generates a file name for CSV files based on the provided name, the current date
  * and the provided params, which are all appended with hyphens.
  *
- * @param   {string}  [name='']     Name of the file
- * @param   {Object}  [params={}]   Object of key-values to append to the file name
+ * @param {string} [name='']   Name of the file
+ * @param {Object} [params={}] Object of key-values to append to the file name
  * @return {string}                Formatted file name
  */
 export function generateCSVFileName( name = '', params = {} ) {
@@ -91,8 +91,8 @@ export function generateCSVFileName( name = '', params = {} ) {
 /**
  * Downloads a CSV file with the given file name and contents
  *
- * @param   {string}  fileName     Name of the file to download
- * @param   {string}  content      Contents of the file to download
+ * @param {string} fileName Name of the file to download
+ * @param {string} content  Contents of the file to download
  */
 export function downloadCSVFile( fileName, content ) {
 	// eslint-disable-next-line no-undef

--- a/packages/currency/src/index.js
+++ b/packages/currency/src/index.js
@@ -42,8 +42,8 @@ const CurrencyFactory = function ( currencySetting ) {
 	/**
 	 * Formats money value.
 	 *
-	 * @param   {number|string} number number to format
-	 * @param   {boolean} [useCode=false] Set to `true` to use the currency code instead of the symbol.
+	 * @param {number|string} number          number to format
+	 * @param {boolean}       [useCode=false] Set to `true` to use the currency code instead of the symbol.
 	 * @return {?string} A formatted string.
 	 */
 	function formatAmount( number, useCode = false ) {
@@ -64,7 +64,7 @@ const CurrencyFactory = function ( currencySetting ) {
 	 *
 	 * @deprecated
 	 *
-	 * @param   {number|string} number number to format
+	 * @param {number|string} number number to format
 	 * @return {?string} A formatted string.
 	 */
 	function formatCurrency( number ) {
@@ -105,8 +105,8 @@ const CurrencyFactory = function ( currencySetting ) {
 	/**
 	 * Get formatted data for a country from supplied locale and symbol info.
 	 *
-	 * @param {string} countryCode Country code.
-	 * @param {Object} localeInfo Locale info by country code.
+	 * @param {string} countryCode     Country code.
+	 * @param {Object} localeInfo      Locale info by country code.
 	 * @param {Object} currencySymbols Currency symbols by symbol code.
 	 * @return {Object} Formatted currency data for country.
 	 */
@@ -167,7 +167,7 @@ const CurrencyFactory = function ( currencySetting ) {
 		 * Get the string representation of a floating point number to the precision used by the current currency.
 		 * This is different from `formatAmount` by not returning the currency symbol.
 		 *
-		 * @param  {number|string} number A floating point number (or integer), or string that converts to a number
+		 * @param {number|string} number A floating point number (or integer), or string that converts to a number
 		 * @return {string}               The original number rounded to a decimal point
 		 */
 		formatDecimalString( number ) {
@@ -184,7 +184,7 @@ const CurrencyFactory = function ( currencySetting ) {
 		/**
 		 * Render a currency for display in a component.
 		 *
-		 * @param  {number|string} number A floating point number (or integer), or string that converts to a number
+		 * @param {number|string} number A floating point number (or integer), or string that converts to a number
 		 * @return {Node|string} The number formatted as currency and rendered for display.
 		 */
 		render( number ) {

--- a/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
+++ b/packages/customer-effort-score/src/customer-feedback-modal/index.tsx
@@ -23,9 +23,9 @@ import { __ } from '@wordpress/i18n';
  *
  * Upon completion, the score and comments is sent to a callback function.
  *
- * @param {Object} props                       Component props.
+ * @param {Object}   props                     Component props.
  * @param {Function} props.recordScoreCallback Function to call when the results are sent.
- * @param {string} props.label                 Question to ask the customer.
+ * @param {string}   props.label               Question to ask the customer.
  */
 function CustomerFeedbackModal( {
 	recordScoreCallback,

--- a/packages/customer-effort-score/src/index.js
+++ b/packages/customer-effort-score/src/index.js
@@ -20,14 +20,14 @@ const noop = () => {};
  * NOTE: This should live in @woocommerce/customer-effort-score to allow
  * reuse.
  *
- * @param {Object} props                             Component props.
+ * @param {Object}   props                           Component props.
  * @param {Function} props.recordScoreCallback       Function to call when the score should be recorded.
- * @param {string} props.label                       The label displayed in the modal.
+ * @param {string}   props.label                     The label displayed in the modal.
  * @param {Function} props.createNotice              Create a notice (snackbar).
  * @param {Function} props.onNoticeShownCallback     Function to call when the notice is shown.
  * @param {Function} props.onNoticeDismissedCallback Function to call when the notice is dismissed.
  * @param {Function} props.onModalShownCallback      Function to call when the modal is shown.
- * @param {Object} props.icon                        Icon (React component) to be shown on the notice.
+ * @param {Object}   props.icon                      Icon (React component) to be shown on the notice.
  */
 export function CustomerEffortScore( {
 	recordScoreCallback,

--- a/packages/data/src/items/utils.js
+++ b/packages/data/src/items/utils.js
@@ -12,13 +12,13 @@ import { getResourceName } from '../utils';
 /**
  * Returns leaderboard data to render a leaderboard table.
  *
- * @param  {Object} options                 arguments
- * @param  {string} options.id              Leaderboard ID
- * @param  {number} options.per_page       Per page limit
- * @param  {Object} options.persisted_query Persisted query passed to endpoint
- * @param  {Object} options.query           Query parameters in the url
- * @param  {Object} options.select          Instance of @wordpress/select
- * @param  {string} options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {string} options.id               Leaderboard ID
+ * @param {number} options.per_page         Per page limit
+ * @param {Object} options.persisted_query  Persisted query passed to endpoint
+ * @param {Object} options.query            Query parameters in the url
+ * @param {Object} options.select           Instance of @wordpress/select
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object} Object containing leaderboard responses.
  */
 export function getLeaderboard( options ) {
@@ -63,10 +63,10 @@ export function getLeaderboard( options ) {
 /**
  * Returns items based on a search query.
  *
- * @param  {Object}   selector    Instance of @wordpress/select response
- * @param  {string}   endpoint  Report API Endpoint
- * @param  {string[]} search    Array of search strings.
- * @param  {Object}   options  Query options.
+ * @param {Object}   selector Instance of @wordpress/select response
+ * @param {string}   endpoint Report API Endpoint
+ * @param {string[]} search   Array of search strings.
+ * @param {Object}   options  Query options.
  * @return {Object}   Object containing API request information and the matching items.
  */
 export function searchItemsByString(
@@ -108,7 +108,7 @@ export function searchItemsByString(
  * totals values like pagination and response field filtering.
  *
  * @param {string} itemType Item type for totals count.
- * @param {Object} query Query for item totals count.
+ * @param {Object} query    Query for item totals count.
  * @return {string} Resource name for item totals.
  */
 export function getTotalCountResourceName( itemType, query ) {

--- a/packages/data/src/options/selectors.js
+++ b/packages/data/src/options/selectors.js
@@ -2,7 +2,7 @@
  * Get option from state tree.
  *
  * @param {Object} state - Reducer state
- * @param {Array} name - Option name
+ * @param {Array}  name  - Option name
  */
 export const getOption = ( state, name ) => {
 	return state[ name ];
@@ -12,7 +12,7 @@ export const getOption = ( state, name ) => {
  * Determine if an options request resulted in an error.
  *
  * @param {Object} state - Reducer state
- * @param {string} name - Option name
+ * @param {string} name  - Option name
  */
 export const getOptionsRequestingError = ( state, name ) => {
 	return state.requestingErrors[ name ] || false;

--- a/packages/data/src/reports/utils.js
+++ b/packages/data/src/reports/utils.js
@@ -26,12 +26,12 @@ import { getResourceName } from '../utils';
 /**
  * Add filters and advanced filters values to a query object.
  *
- * @param  {Object} options                   arguments
- * @param  {string} options.endpoint          Report API Endpoint
- * @param  {Object} options.query             Query parameters in the url
- * @param  {Array}  options.limitBy           Properties used to limit the results. It will be used in the API call to send the IDs.
- * @param  {Array}  [options.filters]         config filters
- * @param  {Object} [options.advancedFilters] config advanced filters
+ * @param {Object} options                   arguments
+ * @param {string} options.endpoint          Report API Endpoint
+ * @param {Object} options.query             Query parameters in the url
+ * @param {Array}  options.limitBy           Properties used to limit the results. It will be used in the API call to send the IDs.
+ * @param {Array}  [options.filters]         config filters
+ * @param {Object} [options.advancedFilters] config advanced filters
  * @return {Object} A query object with the values from filters and advanced fitlters applied.
  */
 export function getFilterQuery( options ) {
@@ -67,7 +67,7 @@ const noIntervalEndpoints = [ 'stock', 'customers' ];
  * Add timestamp to advanced filter parameters involving date. The api
  * expects a timestamp for these values similar to `before` and `after`.
  *
- * @param {Object} config - advancedFilters config object.
+ * @param {Object} config       - advancedFilters config object.
  * @param {Object} activeFilter - an active filter.
  * @return {Object} - an active filter with timestamp added to date values.
  */
@@ -158,8 +158,8 @@ export function getQueryFromConfig( config, advancedFilters, query ) {
 /**
  * Returns true if a report object is empty.
  *
- * @param  {Object}  report   Report to check
- * @param  {string}  endpoint Endpoint slug
+ * @param {Object} report   Report to check
+ * @param {string} endpoint Endpoint slug
  * @return {boolean}        True if report is data is empty.
  */
 export function isReportDataEmpty( report, endpoint ) {
@@ -186,12 +186,12 @@ export function isReportDataEmpty( report, endpoint ) {
 /**
  * Constructs and returns a query associated with a Report data request.
  *
- * @param  {Object} options           arguments
- * @param  {string} options.endpoint  Report API Endpoint
- * @param  {string} options.dataType  'primary' or 'secondary'.
- * @param  {Object} options.query     Query parameters in the url.
- * @param  {Array}  options.limitBy   Properties used to limit the results. It will be used in the API call to send the IDs.
- * @param  {string}  options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {string} options.endpoint         Report API Endpoint
+ * @param {string} options.dataType         'primary' or 'secondary'.
+ * @param {Object} options.query            Query parameters in the url.
+ * @param {Array}  options.limitBy          Properties used to limit the results. It will be used in the API call to send the IDs.
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object} data request query parameters.
  */
 function getRequestQuery( options ) {
@@ -222,12 +222,12 @@ function getRequestQuery( options ) {
 /**
  * Returns summary number totals needed to render a report page.
  *
- * @param  {Object} options           arguments
- * @param  {string} options.endpoint  Report API Endpoint
- * @param  {Object} options.query     Query parameters in the url
- * @param  {Object} options.select    Instance of @wordpress/select
- * @param  {Array}  options.limitBy   Properties used to limit the results. It will be used in the API call to send the IDs.
- * @param  {string}  options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {string} options.endpoint         Report API Endpoint
+ * @param {Object} options.query            Query parameters in the url
+ * @param {Object} options.select           Instance of @wordpress/select
+ * @param {Array}  options.limitBy          Properties used to limit the results. It will be used in the API call to send the IDs.
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object} Object containing summary number responses.
  */
 export function getSummaryNumbers( options ) {
@@ -339,14 +339,14 @@ const getReportChartDataResponse = memoize(
 /**
  * Returns all of the data needed to render a chart with summary numbers on a report page.
  *
- * @param  {Object} options           arguments
- * @param  {string} options.endpoint  Report API Endpoint
- * @param  {string} options.dataType  'primary' or 'secondary'
- * @param  {Object} options.query     Query parameters in the url
- * @param  {Object} options.selector    Instance of @wordpress/select response
- * @param  {Object} options.select    (Depreciated) Instance of @wordpress/select
- * @param  {Array}  options.limitBy   Properties used to limit the results. It will be used in the API call to send the IDs.
- * @param  {string}  options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {string} options.endpoint         Report API Endpoint
+ * @param {string} options.dataType         'primary' or 'secondary'
+ * @param {Object} options.query            Query parameters in the url
+ * @param {Object} options.selector         Instance of @wordpress/select response
+ * @param {Object} options.select           (Depreciated) Instance of @wordpress/select
+ * @param {Array}  options.limitBy          Properties used to limit the results. It will be used in the API call to send the IDs.
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object}  Object containing API request information (response, fetching, and error details)
  */
 export function getReportChartData( options ) {
@@ -445,8 +445,8 @@ export function getReportChartData( options ) {
 /**
  * Returns a formatting function or string to be used by d3-format
  *
- * @param  {string} type Type of number, 'currency', 'number', 'percent', 'average'
- * @param  {Function} formatAmount format currency function
+ * @param {string}   type         Type of number, 'currency', 'number', 'percent', 'average'
+ * @param {Function} formatAmount format currency function
  * @return {string|Function}  returns a number format based on the type or an overriding formatting function
  */
 export function getTooltipValueFormat( type, formatAmount ) {
@@ -467,10 +467,10 @@ export function getTooltipValueFormat( type, formatAmount ) {
 /**
  * Returns query needed for a request to populate a table.
  *
- * @param  {Object} options              arguments
- * @param  {Object} options.query        Query parameters in the url
- * @param  {Object} options.tableQuery   Query parameters specific for that endpoint
- * @param  {string} options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {Object} options.query            Query parameters in the url
+ * @param {Object} options.tableQuery       Query parameters specific for that endpoint
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object} Object    Table data response
  */
 export function getReportTableQuery( options ) {
@@ -499,13 +499,13 @@ export function getReportTableQuery( options ) {
 /**
  * Returns table data needed to render a report page.
  *
- * @param  {Object} options                arguments
- * @param  {string} options.endpoint       Report API Endpoint
- * @param  {Object} options.query          Query parameters in the url
- * @param  {Object} options.selector       Instance of @wordpress/select response
- * @param  {Object} options.select         (depreciated) Instance of @wordpress/select
- * @param  {Object} options.tableQuery     Query parameters specific for that endpoint
- * @param  {string}  options.defaultDateRange   User specified default date range.
+ * @param {Object} options                  arguments
+ * @param {string} options.endpoint         Report API Endpoint
+ * @param {Object} options.query            Query parameters in the url
+ * @param {Object} options.selector         Instance of @wordpress/select response
+ * @param {Object} options.select           (depreciated) Instance of @wordpress/select
+ * @param {Object} options.tableQuery       Query parameters specific for that endpoint
+ * @param {string} options.defaultDateRange User specified default date range.
  * @return {Object} Object    Table data response
  */
 export function getReportTableData( options ) {

--- a/packages/data/src/settings/selectors.js
+++ b/packages/data/src/settings/selectors.js
@@ -54,17 +54,17 @@ export const isUpdateSettingsRequesting = ( state, group ) => {
 /**
  * Retrieves a setting value from the setting store.
  *
- * @param {Object}   state                        State param added by wp.data.
- * @param {string}   group                        The settings group.
- * @param {string}   name                         The identifier for the setting.
- * @param {*}    [fallback=false]             The value to use as a fallback
- *                                                if the setting is not in the
- *                                                state.
- * @param {Function} [filter=( val ) => val]  	  A callback for filtering the
- *                                                value before it's returned.
- *                                                Receives both the found value
- *                                                (if it exists for the key) and
- *                                                the provided fallback arg.
+ * @param {Object}   state                   State param added by wp.data.
+ * @param {string}   group                   The settings group.
+ * @param {string}   name                    The identifier for the setting.
+ * @param {*}        [fallback=false]        The value to use as a fallback
+ *                                           if the setting is not in the
+ *                                           state.
+ * @param {Function} [filter=( val ) => val] A callback for filtering the
+ *                                           value before it's returned.
+ *                                           Receives both the found value
+ *                                           (if it exists for the key) and
+ *                                           the provided fallback arg.
  *
  * @return {*}  The value present in the settings state for the given
  *                   name.

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -14,9 +14,9 @@ export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss';
  * DateValue Object
  *
  * @typedef  {Object} DateValue - Describes the date range supplied by the date picker.
- * @property {string} label - The translated value of the period.
- * @property {string} range - The human readable value of a date range.
- * @property {moment.Moment} after - Start of the date range.
+ * @property {string}        label  - The translated value of the period.
+ * @property {string}        range  - The human readable value of a date range.
+ * @property {moment.Moment} after  - Start of the date range.
  * @property {moment.Moment} before - End of the date range.
  */
 
@@ -24,10 +24,10 @@ export const defaultDateTimeFormat = 'YYYY-MM-DDTHH:mm:ss';
  * DateParams Object
  *
  * @typedef {Object} DateParams - date parameters derived from query parameters.
- * @property {string} period - period value, ie `last_week`
- * @property {string} compare - compare valuer, ie previous_year
- * @param {moment.Moment|null} after - If the period supplied is "custom", this is the after date
- * @param {moment.Moment|null} before - If the period supplied is "custom", this is the before date
+ * @property {string}             period  - period value, ie `last_week`
+ * @property {string}             compare - compare valuer, ie previous_year
+ * @param    {moment.Moment|null} after   - If the period supplied is "custom", this is the after date
+ * @param    {moment.Moment|null} before  - If the period supplied is "custom", this is the before date
  */
 
 export const presetValues = [
@@ -58,8 +58,8 @@ export const periods = [
 /**
  * Adds timestamp to a string date.
  *
- * @param {moment.Moment} date - Date as a moment object.
- * @param {string} timeOfDay - Either `start`, `now` or `end` of the day.
+ * @param {moment.Moment} date      - Date as a moment object.
+ * @param {string}        timeOfDay - Either `start`, `now` or `end` of the day.
  * @return {string} - String date with timestamp attached.
  */
 export const appendTimestamp = ( date, timeOfDay ) => {
@@ -83,7 +83,7 @@ export const appendTimestamp = ( date, timeOfDay ) => {
  * Convert a string to Moment object
  *
  * @param {string} format - localized date string format
- * @param {string} str - date string
+ * @param {string} str    - date string
  * @return {Object|null} - Moment object representing given string
  */
 export function toMoment( format, str ) {
@@ -100,7 +100,7 @@ export function toMoment( format, str ) {
 /**
  * Given two dates, derive a string representation
  *
- * @param {Object} after - start date
+ * @param {Object} after  - start date
  * @param {Object} before - end date
  * @return {string} - text value for the supplied date range
  */
@@ -149,7 +149,7 @@ export function getStoreTimeZoneMoment() {
 /**
  * Get a DateValue object for a period prior to the current period.
  *
- * @param {string} period - the chosen period
+ * @param {string} period  - the chosen period
  * @param {string} compare - `previous_period` or `previous_year`
  * @return {DateValue} -  DateValue data about the selected period
  */
@@ -198,7 +198,7 @@ export function getLastPeriod( period, compare ) {
  * Get a DateValue object for a curent period. The period begins on the first day of the period,
  * and ends on the current day.
  *
- * @param {string} period - the chosen period
+ * @param {string} period  - the chosen period
  * @param {string} compare - `previous_period` or `previous_year`
  * @return {DateValue} -  DateValue data about the selected period
  */
@@ -233,9 +233,9 @@ export function getCurrentPeriod( period, compare ) {
  * Get a DateValue object for a period described by a period, compare value, and start/end
  * dates, for custom dates.
  *
- * @param {string} period - the chosen period
- * @param {string} compare - `previous_period` or `previous_year`
- * @param {Object} [after] - after date if custom period
+ * @param {string} period   - the chosen period
+ * @param {string} compare  - `previous_period` or `previous_year`
+ * @param {Object} [after]  - after date if custom period
  * @param {Object} [before] - before date if custom period
  * @return {DateValue} - DateValue data about the selected period
  */
@@ -296,10 +296,10 @@ const getDateValue = memoize(
 /**
  * Memoized internal logic of getDateParamsFromQuery().
  *
- * @param {string} period - period value, ie `last_week`
- * @param {string} compare - compare value, ie `previous_year`
- * @param {string} after - date in iso date format, ie `2018-07-03`
- * @param {string} before - date in iso date format, ie `2018-07-03`
+ * @param {string} period           - period value, ie `last_week`
+ * @param {string} compare          - compare value, ie `previous_year`
+ * @param {string} after            - date in iso date format, ie `2018-07-03`
+ * @param {string} before           - date in iso date format, ie `2018-07-03`
  * @param {string} defaultDateRange - the store's default date range
  * @return {Object} - date parameters derived from query parameters with added defaults
  */
@@ -333,11 +333,11 @@ const getDateParamsFromQueryMemoized = memoize(
 /**
  * Add default date-related parameters to a query object
  *
- * @param {Object} query - query object
- * @param {string} query.period - period value, ie `last_week`
- * @param {string} query.compare - compare value, ie `previous_year`
- * @param {string} query.after - date in iso date format, ie `2018-07-03`
- * @param {string} query.before - date in iso date format, ie `2018-07-03`
+ * @param {Object} query            - query object
+ * @param {string} query.period     - period value, ie `last_week`
+ * @param {string} query.compare    - compare value, ie `previous_year`
+ * @param {string} query.after      - date in iso date format, ie `2018-07-03`
+ * @param {string} query.before     - date in iso date format, ie `2018-07-03`
  * @param {string} defaultDateRange - the store's default date range
  * @return {DateParams} - date parameters derived from query parameters with added defaults
  */
@@ -359,12 +359,12 @@ export const getDateParamsFromQuery = (
 /**
  * Memoized internal logic of getCurrentDates().
  *
- * @param {string} period - period value, ie `last_week`
- * @param {string} compare - compare value, ie `previous_year`
- * @param {Object} primaryStart - primary query start DateTime, in Moment instance.
- * @param {Object} primaryEnd - primary query start DateTime, in Moment instance.
+ * @param {string} period         - period value, ie `last_week`
+ * @param {string} compare        - compare value, ie `previous_year`
+ * @param {Object} primaryStart   - primary query start DateTime, in Moment instance.
+ * @param {Object} primaryEnd     - primary query start DateTime, in Moment instance.
  * @param {Object} secondaryStart - primary query start DateTime, in Moment instance.
- * @param {Object} secondaryEnd - primary query start DateTime, in Moment instance.
+ * @param {Object} secondaryEnd   - primary query start DateTime, in Moment instance.
  * @return {{primary: DateValue, secondary: DateValue}} - Primary and secondary DateValue objects
  */
 const getCurrentDatesMemoized = memoize(
@@ -411,11 +411,11 @@ const getCurrentDatesMemoized = memoize(
 /**
  * Get Date Value Objects for a primary and secondary date range
  *
- * @param {Object} query - query object
- * @param {string} query.period - period value, ie `last_week`
- * @param {string} query.compare - compare value, ie `previous_year`
- * @param {string} query.after - date in iso date format, ie `2018-07-03`
- * @param {string} query.before - date in iso date format, ie `2018-07-03`
+ * @param {Object} query            - query object
+ * @param {string} query.period     - period value, ie `last_week`
+ * @param {string} query.compare    - compare value, ie `previous_year`
+ * @param {string} query.after      - date in iso date format, ie `2018-07-03`
+ * @param {string} query.before     - date in iso date format, ie `2018-07-03`
  * @param {string} defaultDateRange - the store's default date range
  * @return {{primary: DateValue, secondary: DateValue}} - Primary and secondary DateValue objects
  */
@@ -447,7 +447,7 @@ export const getCurrentDates = (
 /**
  * Calculates the date difference between two dates. Used in calculating a matching date for previous period.
  *
- * @param {string} date - Date to compare
+ * @param {string} date  - Date to compare
  * @param {string} date2 - Seconary date to compare
  * @return {number}  - Difference in days.
  */
@@ -460,10 +460,10 @@ export const getDateDifferenceInDays = ( date, date2 ) => {
 /**
  * Get the previous date for either the previous period of year.
  *
- * @param {string} date - Base date
- * @param {string} date1 - primary start
- * @param {string} date2 - secondary start
- * @param {string} compare - `previous_period`  or `previous_year`
+ * @param {string} date     - Base date
+ * @param {string} date1    - primary start
+ * @param {string} date2    - secondary start
+ * @param {string} compare  - `previous_period`  or `previous_year`
  * @param {string} interval - interval
  * @return {Object}  - Calculated date
  */
@@ -484,7 +484,7 @@ export const getPreviousDate = ( date, date1, date2, compare, interval ) => {
 /**
  * Returns the allowed selectable intervals for a specific query.
  *
- * @param  {Object} query Current query
+ * @param {Object} query            Current query
  * @param {string} defaultDateRange - the store's default date range
  * @return {Array} Array containing allowed intervals.
  */
@@ -546,7 +546,7 @@ export function getAllowedIntervalsForQuery(
 /**
  * Returns the current interval to use.
  *
- * @param {Object} query Current query
+ * @param {Object} query            Current query
  * @param {string} defaultDateRange - the store's default date range
  * @return {string} Current interval.
  */
@@ -567,7 +567,7 @@ export function getIntervalForQuery(
 /**
  * Returns the current chart type to use.
  *
- * @param {Object} query Current query
+ * @param {Object} query           Current query
  * @param {string} query.chartType
  * @return {string} Current chart type.
  */
@@ -585,9 +585,9 @@ export const defaultTableDateFormat = 'm/d/Y';
 /**
  * Returns date formats for the current interval.
  *
- * @param {string} interval Interval to get date formats for.
- * @param {number} [ticks] Number of ticks the axis will have.
- * @param {Object} [option] Options
+ * @param {string} interval      Interval to get date formats for.
+ * @param {number} [ticks]       Number of ticks the axis will have.
+ * @param {Object} [option]      Options
  * @param {string} [option.type] Date format type, d3 or php, defaults to d3.
  * @return {string} Current interval.
  */
@@ -610,8 +610,8 @@ export function getDateFormatsForInterval(
  * Returns d3 date formats for the current interval.
  * See https://github.com/d3/d3-time-format for chart formats.
  *
- * @param  {string} interval Interval to get date formats for.
- * @param  {number}    [ticks] Number of ticks the axis will have.
+ * @param {string} interval Interval to get date formats for.
+ * @param {number} [ticks]  Number of ticks the axis will have.
  * @return {string} Current interval.
  */
 export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
@@ -683,8 +683,8 @@ export function getDateFormatsForIntervalD3( interval, ticks = 0 ) {
  * Returns php date formats for the current interval.
  * See see https://www.php.net/manual/en/datetime.format.php.
  *
- * @param  {string} interval Interval to get date formats for.
- * @param  {number}    [ticks] Number of ticks the axis will have.
+ * @param {string} interval Interval to get date formats for.
+ * @param {number} [ticks]  Number of ticks the axis will have.
  * @return {string} Current interval.
  */
 export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
@@ -756,9 +756,9 @@ export function getDateFormatsForIntervalPhp( interval, ticks = 0 ) {
  * PHP date formats, ie 'LLL: "F j, Y g:i a"'. Override those with translations
  * of moment style js formats.
  *
- * @param {Object} config Locale config object, from store settings.
+ * @param {Object} config               Locale config object, from store settings.
  * @param {string} config.userLocale
- * @param {Array} config.weekdaysShort
+ * @param {Array}  config.weekdaysShort
  */
 export function loadLocaleData( { userLocale, weekdaysShort } ) {
 	// Don't update if the wp locale hasn't been set yet, like in unit tests, for instance.
@@ -791,18 +791,18 @@ export const dateValidationMessages = {
 
 /**
  * @typedef {Object} validatedDate
- * @property {Object|null} date - A resulting Moment date object or null, if invalid
- * @property {string} error - An optional error message if date is invalid
+ * @property {Object|null} date  - A resulting Moment date object or null, if invalid
+ * @property {string}      error - An optional error message if date is invalid
  */
 
 /**
  * Validate text input supplied for a date range.
  *
- * @param {string} type - Designate beginning or end of range, eg `before` or `after`.
- * @param {string} value - User input value
+ * @param {string}      type     - Designate beginning or end of range, eg `before` or `after`.
+ * @param {string}      value    - User input value
  * @param {Object|null} [before] - If already designated, the before date parameter
- * @param {Object|null} [after] - If already designated, the after date parameter
- * @param {string} format - The expected date format in a user's locale
+ * @param {Object|null} [after]  - If already designated, the after date parameter
+ * @param {string}      format   - The expected date format in a user's locale
  * @return {Object} validatedDate - validated date object
  */
 export function validateDateInputForRange(

--- a/packages/eslint-plugin/rules/dependency-group.js
+++ b/packages/eslint-plugin/rules/dependency-group.js
@@ -138,8 +138,8 @@ module.exports = {
 		/**
 		 * Tests if the locality is defined in the correct order (External, WooCommerce, Internal).
 		 *
-		 * @param {espree.Node}       child    Node to test.
-		 * @param {WCPackageLocality} locality Package locality.
+		 * @param {espree.Node}       child            Node to test.
+		 * @param {WCPackageLocality} locality         Package locality.
 		 * @param {WCPackageLocality} previousLocality Previous package locality.
 		 */
 		function checkLocalityOrder( child, locality, previousLocality ) {

--- a/packages/experimental/src/experimental-list/collapsible-list/index.tsx
+++ b/packages/experimental/src/experimental-list/collapsible-list/index.tsx
@@ -60,9 +60,9 @@ function getContainerHeight( collapseContainer: HTMLDivElement | null ) {
  * If one is removed, it will remove it from the show array.
  * If one is added, it will add it back to the shown list, making use of the new children list to keep order.
  *
- * @param {Array.<import('react').ReactElement>} currentChildren a list of the current children.
+ * @param {Array.<import('react').ReactElement>} currentChildren      a list of the current children.
  * @param {Array.<import('react').ReactElement>} currentShownChildren a list of the current shown children.
- * @param {Array.<import('react').ReactElement>} newChildren a list of the new children.
+ * @param {Array.<import('react').ReactElement>} newChildren          a list of the new children.
  * @return {Array.<import('react').ReactElement>} new list of children that should be shown.
  */
 function getUpdatedShownChildren(

--- a/packages/navigation/src/filters.js
+++ b/packages/navigation/src/filters.js
@@ -27,15 +27,15 @@ export function flattenFilters( filters ) {
  * Describe activeFilter object.
  *
  * @typedef {Object} activeFilter
- * @property {string} key - filter key.
+ * @property {string} key    - filter key.
  * @property {string} [rule] - a modifying rule for a filter, eg 'includes' or 'is_not'.
- * @property {string} value - filter value(s).
+ * @property {string} value  - filter value(s).
  */
 
 /**
  * Given a query object, return an array of activeFilters, if any.
  *
- * @param {Object} query - query oject
+ * @param {Object} query  - query oject
  * @param {Object} config - config object
  * @return {Array} - array of activeFilters
  */
@@ -104,8 +104,8 @@ export function getActiveFiltersFromQuery( query, config ) {
  * Get the default option's value from the configuration object for a given filter. The first
  * option is used as default if no `defaultOption` is provided.
  *
- * @param {Object} config - a filter config object.
- * @param {Array} options - select options.
+ * @param {Object} config  - a filter config object.
+ * @param {Array}  options - select options.
  * @return {string|undefined}  - the value of the default option.
  */
 export function getDefaultOptionValue( config, options ) {
@@ -129,9 +129,9 @@ export function getDefaultOptionValue( config, options ) {
  * Given activeFilters, create a new query object to update the url. Use previousFilters to
  * Remove unused params.
  *
- * @param {Array} activeFilters - Array of activeFilters shown in the UI
- * @param {Object} query - the current url query object
- * @param {Object} config - config object
+ * @param {Array}  activeFilters - Array of activeFilters shown in the UI
+ * @param {Object} query         - the current url query object
+ * @param {Object} config        - config object
  * @return {Object} - query object representing the new parameters
  */
 export function getQueryFromActiveFilters( activeFilters, query, config ) {
@@ -170,7 +170,7 @@ export function getQueryFromActiveFilters( activeFilters, query, config ) {
 /**
  * Get the url query key from the filter key and rule.
  *
- * @param {string} key - filter key.
+ * @param {string} key  - filter key.
  * @param {string} rule - filter rule.
  * @return {string} - url query key.
  */

--- a/packages/navigation/src/index.js
+++ b/packages/navigation/src/index.js
@@ -144,10 +144,10 @@ export function getSearchWords( query = navUtils.getQuery() ) {
 /**
  * Return a URL with set query parameters.
  *
- * @param {Object} query object of params to be updated.
- * @param {string} path Relative path (defaults to current path).
+ * @param {Object} query        object of params to be updated.
+ * @param {string} path         Relative path (defaults to current path).
  * @param {Object} currentQuery object of current query params (defaults to current querystring).
- * @param {string} page Page key (defaults to "wc-admin")
+ * @param {string} page         Page key (defaults to "wc-admin")
  * @return {string}  Updated URL merging query params into existing params.
  */
 export function getNewPath(
@@ -180,7 +180,7 @@ export function getQuery() {
  * This function returns an event handler for the given `param`
  *
  * @param {string} param The parameter in the querystring which should be updated (ex `page`, `per_page`)
- * @param {string} path Relative path (defaults to current path).
+ * @param {string} path  Relative path (defaults to current path).
  * @param {string} query object of current query params (defaults to current querystring).
  * @return {Function} A callback which will update `param` to the passed value when called.
  */
@@ -209,10 +209,10 @@ export function onQueryChange( param, path = getPath(), query = getQuery() ) {
 /**
  * Updates the query parameters of the current page.
  *
- * @param {Object} query object of params to be updated.
- * @param {string} path Relative path (defaults to current path).
+ * @param {Object} query        object of params to be updated.
+ * @param {string} path         Relative path (defaults to current path).
  * @param {Object} currentQuery object of current query params (defaults to current querystring).
- * @param {string} page Page key (defaults to "wc-admin")
+ * @param {string} page         Page key (defaults to "wc-admin")
  */
 export function updateQueryString(
 	query,
@@ -271,9 +271,9 @@ export const addHistoryListener = ( listener ) => {
  *
  * @slotFill WooNavigationItem
  * @scope woocommerce-navigation
- * @param {Object} props React props.
- * @param {Array} props.children Node children.
- * @param {string} props.item Navigation item slug.
+ * @param {Object} props          React props.
+ * @param {Array}  props.children Node children.
+ * @param {string} props.item     Navigation item slug.
  */
 export const WooNavigationItem = ( { children, item } ) => {
 	return <Fill name={ 'woocommerce_navigation_' + item }>{ children }</Fill>;

--- a/packages/notices/src/store/actions.js
+++ b/packages/notices/src/store/actions.js
@@ -11,11 +11,11 @@ import { DEFAULT_CONTEXT, DEFAULT_STATUS } from './constants';
 /**
  * @typedef {Object} WPNoticeAction Object describing a user action option associated with a notice.
  *
- * @property {string}    label    Message to use as action label.
- * @property {?string}   url      Optional URL of resource if action incurs
- *                                browser navigation.
- * @property {?Function} onClick  Optional function to invoke when action is
- *                                triggered by user.
+ * @property {string}    label   Message to use as action label.
+ * @property {?string}   url     Optional URL of resource if action incurs
+ *                               browser navigation.
+ * @property {?Function} onClick Optional function to invoke when action is
+ *                               triggered by user.
  *
  */
 

--- a/packages/notices/src/store/selectors.js
+++ b/packages/notices/src/store/selectors.js
@@ -19,26 +19,26 @@ const DEFAULT_NOTICES = [];
 /**
  * @typedef {Object} WPNotice Notice object.
  *
- * @property {string}  id               Unique identifier of notice.
- * @property {string}  status           Status of notice, one of `success`,
- *                                      `info`, `error`, or `warning`. Defaults
- *                                      to `info`.
- * @property {string}  content          Notice message.
- * @property {string}  spokenMessage    Audibly announced message text used by
- *                                      assistive technologies.
- * @property {string}  __unstableHTML   Notice message as raw HTML. Intended to
- *                                      serve primarily for compatibility of
- *                                      server-rendered notices, and SHOULD NOT
- *                                      be used for notices. It is subject to
- *                                      removal without notice.
- * @property {boolean} isDismissible    Whether the notice can be dismissed by
- *                                      user. Defaults to `true`.
- * @property {string}  type             Type of notice, one of `default`,
- *                                      or `snackbar`. Defaults to `default`.
- * @property {boolean} speak            Whether the notice content should be
- *                                      announced to screen readers. Defaults to
- *                                      `true`.
- * @property {WPNoticeAction[]} actions User actions to present with notice.
+ * @property {string}           id             Unique identifier of notice.
+ * @property {string}           status         Status of notice, one of `success`,
+ *                                             `info`, `error`, or `warning`. Defaults
+ *                                             to `info`.
+ * @property {string}           content        Notice message.
+ * @property {string}           spokenMessage  Audibly announced message text used by
+ *                                             assistive technologies.
+ * @property {string}           __unstableHTML Notice message as raw HTML. Intended to
+ *                                             serve primarily for compatibility of
+ *                                             server-rendered notices, and SHOULD NOT
+ *                                             be used for notices. It is subject to
+ *                                             removal without notice.
+ * @property {boolean}          isDismissible  Whether the notice can be dismissed by
+ *                                             user. Defaults to `true`.
+ * @property {string}           type           Type of notice, one of `default`,
+ *                                             or `snackbar`. Defaults to `default`.
+ * @property {boolean}          speak          Whether the notice content should be
+ *                                             announced to screen readers. Defaults to
+ *                                             `true`.
+ * @property {WPNoticeAction[]} actions        User actions to present with notice.
  *
  */
 

--- a/packages/number/src/index.js
+++ b/packages/number/src/index.js
@@ -4,11 +4,11 @@ const numberFormatter = require( 'locutus/php/strings/number_format' );
  * Formats a number using site's current locale
  *
  * @see http://locutus.io/php/strings/number_format/
- * @param {Object} numberConfig number formatting configuration object.
- * @param {number} numberConfig.precision
- * @param {string} numberConfig.decimalSeparator
- * @param {string} numberConfig.thousandSeparator
- * @param {number|string} number number to format
+ * @param {Object}        numberConfig                   number formatting configuration object.
+ * @param {number}        numberConfig.precision
+ * @param {string}        numberConfig.decimalSeparator
+ * @param {string}        numberConfig.thousandSeparator
+ * @param {number|string} number                         number to format
  * @return {?string} A formatted string.
  */
 export function numberFormat(
@@ -42,8 +42,8 @@ export function numberFormat(
  * Formats a number string based on type of `average` or `number`.
  *
  * @param {Object} numberConfig number formatting configuration object.
- * @param {string} type of number to format, average or number
- * @param {number} value to format.
+ * @param {string} type         of number to format, average or number
+ * @param {number} value        to format.
  * @return {?string} A formatted string.
  */
 export function formatValue( numberConfig, type, value ) {
@@ -62,7 +62,7 @@ export function formatValue( numberConfig, type, value ) {
 /**
  * Calculates the delta/percentage change between two numbers.
  *
- * @param {number} primaryValue the value to calculate change for.
+ * @param {number} primaryValue   the value to calculate change for.
  * @param {number} secondaryValue the baseline which to calculdate the change against.
  * @return {?number} Percent change between the primaryValue from the secondaryValue.
  */

--- a/packages/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
+++ b/packages/onboarding/src/components/WooOnboardingTask/WooOnboardingTask.js
@@ -33,7 +33,7 @@ export const trackView = ( taskId ) => {
  *
  * @slotFill WooOnboardingTask
  * @scope woocommerce-tasks
- * @param {Object} props React props.
+ * @param {Object} props    React props.
  * @param {string} props.id Task id.
  */
 const WooOnboardingTask = ( { id, ...props } ) => {

--- a/packages/onboarding/src/components/WooOnboardingTaskListItem/WooOnboardingTaskListItem.js
+++ b/packages/onboarding/src/components/WooOnboardingTaskListItem/WooOnboardingTaskListItem.js
@@ -9,7 +9,7 @@ import { Slot, Fill } from '@wordpress/components';
  *
  * @slotFill WooOnboardingTaskListItem
  * @scope woocommerce-tasks
- * @param {Object} props React props.
+ * @param {Object} props    React props.
  * @param {string} props.id Task id.
  */
 export const WooOnboardingTaskListItem = ( { id, ...props } ) => (

--- a/packages/onboarding/src/components/WooPaymentGatewayConfigure/WooPaymentGatewayConfigure.js
+++ b/packages/onboarding/src/components/WooPaymentGatewayConfigure/WooPaymentGatewayConfigure.js
@@ -9,7 +9,7 @@ import { Slot, Fill } from '@wordpress/components';
  *
  * @slotFill WooPaymentGatewayConfigure
  * @scope woocommerce-admin
- * @param {Object} props React props.
+ * @param {Object} props    React props.
  * @param {string} props.id gateway id.
  */
 export const WooPaymentGatewayConfigure = ( { id, ...props } ) => (

--- a/packages/onboarding/src/components/WooPaymentGatewaySetup/WooPaymentGatewaySetup.js
+++ b/packages/onboarding/src/components/WooPaymentGatewaySetup/WooPaymentGatewaySetup.js
@@ -9,7 +9,7 @@ import { Slot, Fill } from '@wordpress/components';
  *
  * @slotFill WooPaymentGatewaySetup
  * @scope woocommerce-admin
- * @param {Object} props React props.
+ * @param {Object} props    React props.
  * @param {string} props.id Setup id.
  */
 export const WooPaymentGatewaySetup = ( { id, ...props } ) => (

--- a/packages/tracks/src/index.js
+++ b/packages/tracks/src/index.js
@@ -11,7 +11,7 @@ const tracksDebug = debug( 'wc-admin:tracks' );
 /**
  * Record an event to Tracks
  *
- * @param {string} eventName The name of the event to record, don't include the wcadmin_ prefix
+ * @param {string} eventName       The name of the event to record, don't include the wcadmin_ prefix
  * @param {Object} eventProperties event properties to include in the event
  */
 export function recordEvent( eventName, eventProperties ) {
@@ -111,7 +111,7 @@ const tracksQueue = {
  * `window.location`. This is an example of a race condition that should be avoided by enqueueing the event,
  * and therefore running it on the next pageview.
  *
- * @param {string} eventName The name of the event to record, don't include the wcadmin_ prefix
+ * @param {string} eventName       The name of the event to record, don't include the wcadmin_ prefix
  * @param {Object} eventProperties event properties to include in the event
  */
 
@@ -122,7 +122,7 @@ export function queueRecordEvent( eventName, eventProperties ) {
 /**
  * Record a page view to Tracks
  *
- * @param {string} path the page/path to record a page view for
+ * @param {string} path            the page/path to record a page view for
  * @param {Object} extraProperties extra event properties to include in the event
  */
 


### PR DESCRIPTION
Fixes `jsdoc/check-line-alignment` eslint warnings via `pnpm run lint:js -- --fix --fix-type=layout`.

In https://github.com/woocommerce/woocommerce-admin/pull/8475 PR, we updated `@wordpress/eslint-plugin` from 8 to 10, and JSDoc alignment check has been added since [@wordpress/eslint-plugin 9.1.0](https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/CHANGELOG.md#enhancement-2).

Please review the changes and confirm this only changes the JSDoc alignment.

no changelog