### PR TITLE
Allow CLI environments to run the install routines

### DIFF
--- a/src-internal/Admin/Install.php
+++ b/src-internal/Admin/Install.php
@@ -103,7 +103,7 @@ class Install {
 	 * Hook in tabs.
 	 */
 	public static function init() {
-		if ( ( is_admin() && ! wp_doing_ajax() ) || wp_doing_cron() ) {
+		if ( ( is_admin() && ! wp_doing_ajax() ) || wp_doing_cron() || defined( 'WP_CLI' ) ) {
 			add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		}
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );


### PR DESCRIPTION
Fixes #8487 

This PR adds `defined('WP_CLI');` check to allow CLI environments to run the WCA install routines.

### Detailed test instructions:

1. Check out [this branch](https://github.com/woocommerce/woocommerce/pull/32078)
2. Follow this [guide](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/tests/e2e/README.md#running-tests) to setup the WC e2e environment.
3. Open `plugins/woocommerce/packages/woocommerce-admin/src-internal/Install.php` and apply the change in this PR.
4. cd to `plugins/woocommerce` and run the following command.

```
BASE_URL=http://localhost:8084/ USER_KEY=admin USER_SECRET=password pnpm wc-api-tests test api
``` 

The test should pass.

no changelog