### PR TITLE
Add `$primary` param back to add_action method

### DIFF
--- a/src-internal/Admin/Notes/InsightFirstProductAndPayment.php
+++ b/src-internal/Admin/Notes/InsightFirstProductAndPayment.php
@@ -51,6 +51,7 @@ class InsightFirstProductAndPayment {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 
@@ -59,6 +60,7 @@ class InsightFirstProductAndPayment {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 

--- a/src-internal/Admin/Notes/InsightFirstSale.php
+++ b/src-internal/Admin/Notes/InsightFirstSale.php
@@ -54,6 +54,7 @@ class InsightFirstSale {
 			__( 'Yes', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 		$note->add_action(
@@ -61,6 +62,7 @@ class InsightFirstSale {
 			__( 'No', 'woocommerce-admin' ),
 			false,
 			Note::E_WC_ADMIN_NOTE_ACTIONED,
+			false,
 			__( 'Thanks for your feedback', 'woocommerce-admin' )
 		);
 

--- a/src/Notes/DataStore.php
+++ b/src/Notes/DataStore.php
@@ -299,7 +299,6 @@ class DataStore extends \WC_Data_Store_WP implements \WC_Object_Data_Store_Inter
 				'%s',
 				'%s',
 				'%s',
-				'%d',
 				'%s',
 				'%s',
 				'%s',

--- a/src/Notes/Note.php
+++ b/src/Notes/Note.php
@@ -616,17 +616,19 @@ class Note extends \WC_Data {
 	/**
 	 * Add an action to the note
 	 *
-	 * @param string $name           Action name (not presented to user).
-	 * @param string $label          Action label (presented as button label).
-	 * @param string $url            Action URL, if navigation needed. Optional.
-	 * @param string $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
-	 * @param string $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
+	 * @param string  $name           Action name (not presented to user).
+	 * @param string  $label          Action label (presented as button label).
+	 * @param string  $url            Action URL, if navigation needed. Optional.
+	 * @param string  $status         Status to transition parent Note to upon click. Defaults to 'actioned'.
+	 * @param boolean $primary        Deprecated since version 3.4.0.
+	 * @param string  $actioned_text The label to display after the note has been actioned but before it is dismissed in the UI.
 	 */
 	public function add_action(
 		$name,
 		$label,
 		$url = '',
 		$status = self::E_WC_ADMIN_NOTE_ACTIONED,
+		$primary = false,
 		$actioned_text = ''
 	) {
 		$name          = wc_clean( $name );


### PR DESCRIPTION
As suggested [here](https://github.com/woocommerce/woocommerce-admin/pull/8474/files#r829672400), we should keep $primary parameter for backward compatibility.

### Screenshots

![Screen Shot 2022-03-18 at 12 31 53](https://user-images.githubusercontent.com/4344253/158938001-3ac3374c-e66d-47f5-b07d-d600c662f0d0.png)


### Detailed test instructions:

1. Use a fresh site
2. Update `woocommerce_admin_install_timestamp` to `1647318173` from option table to show `InsightFirstProductAndPayment` note
3. Go to **Tools > Cron Events**
4. Run `wc_admin_daily`
5. Go to **WooCommerce > Home**
6. Confirm "Insight" note are shown
7. Click yes or no button
8. Should see "Thanks for your feedback" text

no changelog