### PR TITLE
Add ability for code-based notes to update

### DIFF
--- a/changelogs/add-8427-ability-for-code-based-notes-to-update
+++ b/changelogs/add-8427-ability-for-code-based-notes-to-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Add
+
+Add ability for code-based notes to update. #8490

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -164,13 +164,22 @@ trait NoteTraits {
 			return;
 		}
 
-		// Update note content if it's changed.
-		$latest_note_content = $note->get_content();
-		if ( $note_in_db->get_content() !== $latest_note_content ) {
-			$note_in_db->set_content( $latest_note_content );
+		$need_save = false;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'title' );
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'content_data' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'type' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'locale' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'source' ) || $need_save;
+		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'actions' ) || $need_save;
+
+		if ( $need_save
+		) {
 			$note_in_db->save();
 		}
 	}
+
+
 	/**
 	 * Get if the note has been actioned.
 	 *
@@ -190,5 +199,65 @@ trait NoteTraits {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Update a note field of note1 if it's different from note2 with getter and setter.
+	 *
+	 * @param Note   $note1 Note to update.
+	 * @param Note   $note2 Note to compare against.
+	 * @param string $field_name Field to update.
+	 * @return bool True if the field was updated.
+	 */
+	private static function update_note_field_if_changed( $note1, $note2, $field_name ) {
+		// We need to serialize the stdObject to compare it.
+		$note1_field_value = self::possibly_convert_object_to_array(
+			call_user_func( array( $note1, 'get_' . $field_name ) )
+		);
+		$note2_field_value = self::possibly_convert_object_to_array(
+			call_user_func( array( $note2, 'get_' . $field_name ) )
+		);
+
+		if ( 'actions' === $field_name ) {
+			// We need to individually compare the action fields because action object from db is different from action object of note. For example, action object from db has "id".
+			$diff        = array_udiff(
+				$note1_field_value,
+				$note2_field_value,
+				function( $action1, $action2 ) {
+					if ( $action1->name === $action2->name &&
+						$action1->label === $action2->label &&
+						$action1->query === $action2->query ) {
+						return 0;
+					}
+					return -1;
+				}
+			);
+			$need_update = count( $diff ) > 0;
+		} else {
+			$need_update = $note1_field_value !== $note2_field_value;
+		}
+
+		if ( $need_update ) {
+			call_user_func(
+				array( $note1, 'set_' . $field_name ),
+				// Get note2 field again because it may have been changed during the comparison.
+				call_user_func( array( $note2, 'get_' . $field_name ) )
+			);
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Convert a value to array if it's a stdClass.
+	 *
+	 * @param mixed $obj variable to convert.
+	 * @return mixed
+	 */
+	private static function possibly_convert_object_to_array( $obj ) {
+		if ( $obj instanceof \stdClass ) {
+			return (array) $obj;
+		}
+		return $obj;
 	}
 }

--- a/src/Notes/NoteTraits.php
+++ b/src/Notes/NoteTraits.php
@@ -173,8 +173,7 @@ trait NoteTraits {
 		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'source' ) || $need_save;
 		$need_save = self::update_note_field_if_changed( $note_in_db, $note, 'actions' ) || $need_save;
 
-		if ( $need_save
-		) {
+		if ( $need_save ) {
 			$note_in_db->save();
 		}
 	}
@@ -219,7 +218,8 @@ trait NoteTraits {
 		);
 
 		if ( 'actions' === $field_name ) {
-			// We need to individually compare the action fields because action object from db is different from action object of note. For example, action object from db has "id".
+			// We need to individually compare the action fields because action object from db is different from action object of note.
+			// For example, action object from db has "id".
 			$diff        = array_udiff(
 				$note1_field_value,
 				$note2_field_value,

--- a/tests/notes/class-wc-tests-note-traits.php
+++ b/tests/notes/class-wc-tests-note-traits.php
@@ -58,6 +58,16 @@ class WC_Tests_NoteTraits extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test should convert to array if it's a stdClass object.
+	 * @return void
+	 */
+	public function test_possibly_convert_object_to_array() {
+		$this->assertEquals( self::possibly_convert_object_to_array( new stdClass() ), array() );
+		$this->assertEquals( self::possibly_convert_object_to_array( 1 ), 1 );
+		$this->assertEquals( self::possibly_convert_object_to_array( 'string' ), 'string' );
+	}
+
+	/**
 	 * Method required to use NoteTraits.
 	 *
 	 * @return Note


### PR DESCRIPTION
Fixes woocommerce/woocommerce#32138

This PR adds the ability to update other note attributes when they're changed.

### Detailed test instructions:

1. Update `woocommerce_admin_install_timestamp` option value to 3 days ago. Get this timestamp on macOS with `date -v-3d +"%s"`.
2. Delete the Install Woo mobile app note in the database. `delete from wp_wc_admin_notes where name = 'wc-admin-mobile-app'`;
3. Install `WP Crontrol` and Run the `wc_admin_daily` cron event.
4. See that the **"Install Woo mobile app"** note is on Home Screen.
5. Change the value of `set_title` in the `src/Notes/MobileApp.php`
6. Run the `wc_admin_daily` cron event.
7. Confirm the note title is updated on the Home screen or `wp_wc_admin_notes` table. 
8. Repeat 5~7 steps with different attributes: `Content data`, `Type`, `Source`, `Actions`.
9. For testing `locale`, change the locale value [here](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Notes/Note.php#L57).

