### PR TITLE
Fix `wc-admin-php-test-suite` Dockerfile for pnpm installation

### DIFF
--- a/docker/wc-admin-php-test-suite/Dockerfile
+++ b/docker/wc-admin-php-test-suite/Dockerfile
@@ -12,11 +12,11 @@ RUN apk --no-cache add \
 	mariadb-client \
 	ncurses \
 	nodejs \
-	pnpm \
 	subversion \
 	unzip \
 	wget
 
+RUN curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm
 COPY install-php-version.sh /tmp/
 RUN chmod u+x /tmp/install-php-version.sh && /tmp/install-php-version.sh
 


### PR DESCRIPTION
Fixes #8491

Cannot install pnpm via apk. Instead, install pnpm with [offical pnpm scripts](https://pnpm.io/installation#nodejs-is-preinstalled).


### Detailed test instructions:

- Should build an image without errors: `docker-compose -f docker/wc-admin-php-test-suite/docker-compose.yml build`


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

no changelog