### PR TITLE
Fix argument forwarding for npm script `lint:js-fix`

### DIFF
--- a/changelogs/fix-lint_js-fix
+++ b/changelogs/fix-lint_js-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Dev
+
+Fixed `npm run lint:js-fix` script. #8496

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"lint:js": "wp-scripts lint-js ./packages ./client --ext=js,ts,tsx",
 		"lint:js:packages": "wp-scripts lint-js ./packages --ext=js,ts,tsx",
 		"lint:js:client": "wp-scripts lint-js ./client --ext=js,ts,tsx",
-		"lint:js-fix": "pnpm run lint:js --fix --ext=js,ts,tsx",
+		"lint:js-fix": "pnpm run lint:js -- --fix --ext=js,ts,tsx",
 		"lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
 		"lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
 		"ts:check": "tsc --build ./tsconfig.json",


### PR DESCRIPTION
`npm run lint:js-fix` does not work as it throws:
```
> @woocommerce/admin-library@3.4.0-dev lint:js-fix /home/tomalec/repos/woocommerce-admin
> pnpm run lint:js --fix --ext=js,ts,tsx

 ERROR   ERROR  Unknown options: 'fix', 'ext'
```

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [n/a] I've tested using only a keyboard (no mouse)
-   [n/a] I've tested using a screen reader
-   [n/a] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [n/a] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

#### Before 
![image](https://user-images.githubusercontent.com/17435/159038303-b0125dcf-246d-46fd-9111-dd3d3abb5e14.png)



### Detailed test instructions:

```
pnpm install
npm run lint:js-fix
```

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
