### PR TITLE
Import namespace for TaskList class

### DIFF
--- a/src-internal/Admin/Onboarding/OnboardingProfile.php
+++ b/src-internal/Admin/Onboarding/OnboardingProfile.php
@@ -6,6 +6,7 @@
 
 namespace Automattic\WooCommerce\Internal\Admin\Onboarding;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\Admin\WCAdminHelper;
 


### PR DESCRIPTION
This PR imports the namespace for `TaskList` class to fix the [failing test](https://github.com/woocommerce/woocommerce/runs/5607664733?check_suite_focus=true) in the Core.

### Detailed test instructions:

1. Start with a fresh install (important)
2. When you're redirected to the OBW, close the window. Do not skip.
3. Lower the value of `woocommerce_version` to `6.3.0`
4. Navigate to the admin area.
5. You should not see any errors.

no changelog
