### PR TITLE
Fix `Additional payments` task visibility

### DIFF
--- a/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -74,7 +74,7 @@ class AdditionalPayments extends Payments {
 		$woocommerce_payments = new WooCommercePayments();
 
 		if ( ! $woocommerce_payments->is_requested() || ! $woocommerce_payments->is_supported() || ! $woocommerce_payments->is_connected() ) {
-			// Hide task if WC Pay is installed via OBW, in supported country, but not connected.
+			// Hide task if WC Pay is not installed via OBW, or is not connected, or the store is located in a country that is not supported by WC Pay.
 			return false;
 		}
 

--- a/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
+++ b/src/Features/OnboardingTasks/Tasks/AdditionalPayments.php
@@ -73,7 +73,7 @@ class AdditionalPayments extends Payments {
 
 		$woocommerce_payments = new WooCommercePayments();
 
-		if ( $woocommerce_payments->is_requested() && $woocommerce_payments->is_supported() && ! $woocommerce_payments->is_connected() ) {
+		if ( ! $woocommerce_payments->is_requested() || ! $woocommerce_payments->is_supported() || ! $woocommerce_payments->is_connected() ) {
 			// Hide task if WC Pay is installed via OBW, in supported country, but not connected.
 			return false;
 		}


### PR DESCRIPTION
Fixes #8505

This PR fixes the `Additional payments` task visibility.

More context [here](https://github.com/woocommerce/woocommerce/issues/32330).

No changelog

### Screenshots

![screenshot-eldest-mite jurassic ninja-2022 03 24-17_15_01](https://user-images.githubusercontent.com/1314156/160002385-ff79b78e-f29b-431e-9d49-c3946beb2402.png)


### Detailed test instructions:

1. Check out this branch and create a `.zip`.
2. In the OBW set your store location as a supported one (e.g.: the US).
3. In the `Business Detail` step, install `WCPay`.
4. Finish the OBW.
5. Verify the `Set up additional payment providers` task is not visible.
6. Setup `WCPay`.
7. Go to the `Home` screen and verify that the `Set up additional payment providers` task is visible now.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
