### PR TITLE
WCPayments task is not visible after installing the plugin

### DIFF
--- a/changelogs/fix-hidden_wcpay_task
+++ b/changelogs/fix-hidden_wcpay_task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Fix
+
+WCPayments task is not visible after installing the plugin #8514

--- a/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
+++ b/client/profile-wizard/steps/business-details/flows/selective-bundle/index.js
@@ -201,7 +201,10 @@ class BusinessDetails extends Component {
 
 		const promises = [
 			this.persistProfileItems( {
-				business_extensions: businessExtensions,
+				business_extensions: [
+					...businessExtensions,
+					...alreadyActivatedExtensions,
+				],
 			} ),
 		];
 


### PR DESCRIPTION
This PR aims to fix the problem mentioned in [this comment](https://github.com/woocommerce/woocommerce/issues/32330#issuecomment-1082928199). After installing WCPayments during the profiler, the WCPayments task should be visible instead of the task `Set up payments`.

It also adds the code to disable the installed plugins in the `Business Details` step in the OBW.

### Screenshots

![screenshot-medieval-mantis jurassic ninja-2022 03 30-16_45_06](https://user-images.githubusercontent.com/1314156/160928161-2c8c7efe-0922-49dc-8c1d-f2a124ccf2cb.png)

![screenshot-four local-2022 03 30-19_18_43](https://user-images.githubusercontent.com/1314156/160940456-89ad40e0-3d4d-4ed5-a7e5-929222407c6f.png)


### Detailed test instructions:

- Create a brand new store (e.g.: using JN).
- Create a zip (using `npm run test:zip`), install it, and activate it.
- In the OBW, during the Business Details, install WCPayments.
- After finishing the OBW the task `Get paid with WooCommerce Payments` should appear instead of the `Set up payments` task.
- Now go back to the step `Business Details > Free features`.
- Verify that the checkbox for `WooCommerce Payments` is disabled.
- Finish the OBW.
- Verify the task `Get paid with WooCommerce Payments` is still there.

### UPDATE
Since the checkbox won't be disabled in this PR, discard the testing step:
> Verify that the checkbox for `WooCommerce Payments` is disabled.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
