### PR TITLE
Update wcpay country support list

### DIFF
--- a/changelogs/update-wcpay_country_support_list
+++ b/changelogs/update-wcpay_country_support_list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update country support list for WooCommerce Payments Task. #8517

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DefaultPaymentGateways;
 use Automattic\WooCommerce\Admin\PluginsHelper;
 
 /**
@@ -145,27 +146,7 @@ class WooCommercePayments extends Task {
 	public static function is_supported() {
 		return in_array(
 			WC()->countries->get_base_country(),
-			array(
-				'US',
-				'PR',
-				'AU',
-				'CA',
-				'DE',
-				'ES',
-				'FR',
-				'GB',
-				'IE',
-				'IT',
-				'NZ',
-				'AT',
-				'BE',
-				'NL',
-				'PL',
-				'PT',
-				'CH',
-				'HK',
-				'SG',
-			),
+			DefaultPaymentGateways::get_wcpay_countries(),
 			true
 		);
 	}

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -157,6 +157,14 @@ class WooCommercePayments extends Task {
 				'IE',
 				'IT',
 				'NZ',
+				'AT',
+				'BE',
+				'NL',
+				'PL',
+				'PT',
+				'CH',
+				'HK',
+				'SG',
 			),
 			true
 		);


### PR DESCRIPTION
Fixes #

This is the simple fix for updating the country support list of the WooCommerce Payments task.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Create a brand new store (e.g.: using JN).
- Start the Onboarding flow and make sure to set the country to Portugal
- During the Business Details, install WCPayments.
- After finishing the OBW the task `Get paid with WooCommerce Payments` should appear instead of the `Set up payments` task.

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
