### PR TITLE
Update WCPay country support list larger fix

### DIFF
--- a/changelogs/update-wcpay_country_support_list_larger_fix
+++ b/changelogs/update-wcpay_country_support_list_larger_fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Update
+
+Update is_supported logic of WooCommerce Payments to keep consistency with other payment data. #8518

--- a/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
+++ b/src/Features/OnboardingTasks/Tasks/WooCommercePayments.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks\Tasks;
 use Automattic\WooCommerce\Admin\Features\Onboarding;
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
 use Automattic\WooCommerce\Admin\PluginsHelper;
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\Init as Suggestions;
 
 /**
  * WooCommercePayments Task
@@ -143,22 +144,12 @@ class WooCommercePayments extends Task {
 	 * @return bool
 	 */
 	public static function is_supported() {
-		return in_array(
-			WC()->countries->get_base_country(),
-			array(
-				'US',
-				'PR',
-				'AU',
-				'CA',
-				'DE',
-				'ES',
-				'FR',
-				'GB',
-				'IE',
-				'IT',
-				'NZ',
-			),
-			true
-		);
+		$suggestions = Suggestions::get_suggestions();
+		$woocommerce_payments_ids = preg_grep( '/^woocommerce_payments/', array_column( $suggestions, 'id' ) );
+
+		if ( false !== $woocommerce_payments_ids && 0 < count( $woocommerce_payments_ids ) ) {
+			return true;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Fixes #

This is a slightly more complicated fix compared to #8517 for updating the country support list of the WooCommerce Payments task.
But this will adhere better to changes on WooCommerce.com if more countries will be added to the support list.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

- Create a brand new store (e.g.: using JN).
- Start the Onboarding flow and make sure to set the country to Portugal
- During the Business Details, install WCPayments.
- After finishing the OBW the task `Get paid with WooCommerce Payments` should appear instead of the `Set up payments` task.


<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
