### PR TITLE
Fix payment gateway warning

### DIFF
--- a/changelogs/fix-payment_gateway_warning
+++ b/changelogs/fix-payment_gateway_warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: Fix
+
+Fix PHP warning when default param is missing in payments spec. #8519

--- a/src/RemoteInboxNotifications/OptionRuleProcessor.php
+++ b/src/RemoteInboxNotifications/OptionRuleProcessor.php
@@ -42,7 +42,7 @@ class OptionRuleProcessor implements RuleProcessorInterface {
 		}
 
 		if ( isset( $rule->transformers ) && is_array( $rule->transformers ) ) {
-			$option_value = TransformerService::apply( $option_value, $rule->transformers, $rule->default );
+			$option_value = TransformerService::apply( $option_value, $rule->transformers, $default );
 		}
 
 		return ComparisonOperation::compare(


### PR DESCRIPTION
Addresses: https://github.com/woocommerce/woocommerce/issues/32154

Make use of `$default` value that checks if `default` exists on the spec.

### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

-   [ ] I've tested using only a keyboard (no mouse)
-   [ ] I've tested using a screen reader
-   [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
-   [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

### Detailed test instructions:

1. On a fresh site, or make sure this transient is deleted `woocommerce_admin_payment_gateway_suggestions_specs`
2. Click on the `Set up payments` task
3. Open up your `debug.log` and make sure there are no warnings

<!--
Please add your test instructions to `/TESTING-INSTRUCTIONS.md`.
-->

<!--- Please add a Changelog note

Enter a changelog note using the following CLI command `pnpm run changelogger -- add` and commit changes. --->
