### PR TITLE
Added a filter to change the Error message and allow developers to add custom text after each table row

### DIFF
--- a/changelogs/a filter to change the Error message and a
+++ b/changelogs/a filter to change the Error message and a
@@ -1,0 +1,4 @@
+Significance: minor
+Type: Enhancement
+
+Added a filter to change the Error message and allow developers to add custom text after each table row

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -14,6 +14,7 @@ import { find, get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 import { Icon, chevronUp, chevronDown } from '@wordpress/icons';
+import { applyFilters } from '@wordpress/hooks';
 
 const ASC = 'asc';
 const DESC = 'desc';
@@ -147,6 +148,7 @@ class Table extends Component {
 			rowHeader,
 			rows,
 		} = this.props;
+
 		const { isScrollableRight, isScrollableLeft, tabIndex } = this.state;
 		const classes = classnames( 'woocommerce-table__table', classNames, {
 			'is-scrollable-right': isScrollableRight,
@@ -300,46 +302,51 @@ class Table extends Component {
 						</tr>
 						{ hasData ? (
 							rows.map( ( row, i ) => (
-								<tr key={ this.getRowKey( row, i ) }>
-									{ row.map( ( cell, j ) => {
-										const {
-											cellClassName,
-											isLeftAligned,
-											isNumeric,
-										} = headers[ j ];
-										const isHeader = rowHeader === j;
-										const Cell = isHeader ? 'th' : 'td';
-										const cellClasses = classnames(
-											'woocommerce-table__item',
-											cellClassName,
-											{
-												'is-left-aligned':
-													isLeftAligned ||
-													! isNumeric,
-												'is-numeric': isNumeric,
-												'is-sorted':
-													sortedBy ===
-													headers[ j ].key,
-											}
-										);
-										const cellKey =
-											this.getRowKey(
-												row,
-												i
-											).toString() + j;
-										return (
-											<Cell
-												scope={
-													isHeader ? 'row' : null
+								applyFilters(
+									'woocommerce_admin_after_table_row',
+									<tr key={ this.getRowKey( row, i ) }>
+										{ row.map( ( cell, j ) => {
+											const {
+												cellClassName,
+												isLeftAligned,
+												isNumeric,
+											} = headers[ j ];
+											const isHeader = rowHeader === j;
+											const Cell = isHeader ? 'th' : 'td';
+											const cellClasses = classnames(
+												'woocommerce-table__item',
+												cellClassName,
+												{
+													'is-left-aligned':
+														isLeftAligned ||
+														! isNumeric,
+													'is-numeric': isNumeric,
+													'is-sorted':
+														sortedBy ===
+														headers[ j ].key,
 												}
-												key={ cellKey }
-												className={ cellClasses }
-											>
-												{ getDisplay( cell ) }
-											</Cell>
-										);
-									} ) }
-								</tr>
+											);
+											const cellKey =
+												this.getRowKey(
+													row,
+													i
+												).toString() + j;
+											return (
+												<Cell
+													scope={
+														isHeader ? 'row' : null
+													}
+													key={ cellKey }
+													className={ cellClasses }
+												>
+													{ getDisplay( cell ) }
+												</Cell>
+											);
+										} ) }
+									</tr>,
+									row,
+									query
+								)
 							) )
 						) : (
 							<tr>

--- a/packages/components/src/table/table.js
+++ b/packages/components/src/table/table.js
@@ -303,7 +303,7 @@ class Table extends Component {
 						{ hasData ? (
 							rows.map( ( row, i ) => (
 								applyFilters(
-									'woocommerce_admin_after_table_row',
+									'woocommerce_admin_table_row',
 									<tr key={ this.getRowKey( row, i ) }>
 										{ row.map( ( cell, j ) => {
 											const {
@@ -344,6 +344,7 @@ class Table extends Component {
 											);
 										} ) }
 									</tr>,
+									i,
 									row,
 									query
 								)
@@ -354,9 +355,12 @@ class Table extends Component {
 									className="woocommerce-table__empty-item"
 									colSpan={ headers.length }
 								>
-									{ __(
-										'No data to display',
-										'woocommerce-admin'
+									{ applyFilters(
+										'woocommerce_admin_nodata_text',
+										__(
+											'No data to display',
+											'woocommerce-admin'
+										)
 									) }
 								</td>
 							</tr>


### PR DESCRIPTION
Fixes #
Currently, there is no way to add custom content right after the <tr> in a table. A filter will help developers who want to toggle certain content when a table row is clicked. It would be great if you could include this filter or a similar solution in the WC tables package.

### Screenshots
https://i.rankmath.com/42piMc
The toggle you see in the screencast is implemented by making the changes directly in the WC table files. 

<!--- Please add a Changelog note
Significance: minor
Type: Enhancement

Added a filter to change the Error message and allow developers to add custom text after each table row
